### PR TITLE
Fix misleading error printing by FileReadLine()

### DIFF
--- a/Managers/LuaMan.cpp
+++ b/Managers/LuaMan.cpp
@@ -1044,9 +1044,6 @@ namespace RTE {
 			if (fgets(buf, sizeof(buf), m_OpenedFiles[fileIndex]) != nullptr) {
 				return buf;
 			}
-#ifndef RELEASE_BUILD
-			g_ConsoleMan.PrintString("ERROR: " + std::string(FileEOF(fileIndex) ? "Tried to read past EOF." : "Failed to read from file."));
-#endif
 		} else {
 			g_ConsoleMan.PrintString("ERROR: Tried to read an invalid or closed file.");
 		}


### PR DESCRIPTION
I described the issue [here](https://github.com/cortex-command-community/Cortex-Command-Community-Project-Source/issues/583#issue-2061123402) in a Source repo Issue.

The tl;dr is that this error should have never been printed here, since mods rely on `fgets()` to return `nullptr` when the end of a file that ends with a newline is reached, which is corroborated by `fgets()` [its man page](https://linux.die.net/man/3/fgets):
> fgets() return *s* on success, and NULL on error or when end of file occurs while no characters have been read.

The important thing to note here is that `FileReadLine()` already correctly returns an empty string when one attempts to read the end of the file.

And no, there is literally no other way for a mod to know whether `FileReadLine()` would print that error on the next call. You can't do it by checking `FileEOF()` before every `FileReadLine()` call, for [the exact same reason](https://stackoverflow.com/a/5605159/13279557) that it doesn't work in C++ with `.eof()`.

This problem hadn't been pointed out by modders before, since the error *only* gets printed during Debug builds of the game, so I wasted a ton of time trying to figure out why I didn't remember seeing the error in my pre4 release executable a year back, when I was working on ModMod.