### PR TITLE
Make GetDirectoryList and GetFileList reentrant

### DIFF
--- a/Managers/LuaMan.cpp
+++ b/Managers/LuaMan.cpp
@@ -68,8 +68,8 @@ namespace RTE {
 				.def("RangeRand", &LuaStateWrapper::RangeRand)
 				.def("PosRand", &LuaStateWrapper::PosRand)
 				.def("NormalRand", &LuaStateWrapper::NormalRand)
-				.def("GetDirectoryList", &LuaStateWrapper::DirectoryList, luabind::return_stl_iterator)
-				.def("GetFileList", &LuaStateWrapper::FileList, luabind::return_stl_iterator)
+				.def("GetDirectoryList", &LuaStateWrapper::DirectoryList, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+				.def("GetFileList", &LuaStateWrapper::FileList, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
 				.def("FileExists", &LuaStateWrapper::FileExists)
 				.def("FileOpen", &LuaStateWrapper::FileOpen)
 				.def("FileClose", &LuaStateWrapper::FileClose)
@@ -273,8 +273,8 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	// Passthrough LuaMan Functions
-	const std::vector<std::string>& LuaStateWrapper::DirectoryList(const std::string& relativeDirectory) { return g_LuaMan.DirectoryList(relativeDirectory); }
-	const std::vector<std::string>& LuaStateWrapper::FileList(const std::string& relativeDirectory) { return g_LuaMan.FileList(relativeDirectory); }
+	const std::vector<std::string>* LuaStateWrapper::DirectoryList(const std::string& relativeDirectory) { return g_LuaMan.DirectoryList(relativeDirectory); }
+	const std::vector<std::string>* LuaStateWrapper::FileList(const std::string& relativeDirectory) { return g_LuaMan.FileList(relativeDirectory); }
 	bool LuaStateWrapper::FileExists(const std::string &fileName) { return g_LuaMan.FileExists(fileName); }
 	int LuaStateWrapper::FileOpen(const std::string& fileName, const std::string& accessMode) { return g_LuaMan.FileOpen(fileName, accessMode); }
 	void LuaStateWrapper::FileClose(int fileIndex) { return g_LuaMan.FileClose(fileIndex); }
@@ -923,24 +923,22 @@ namespace RTE {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	const std::vector<std::string> & LuaMan::DirectoryList(const std::string &filePath) {
-		thread_local std::vector<std::string> directoryPaths;
-		directoryPaths.clear();
+	const std::vector<std::string> * LuaMan::DirectoryList(const std::string &filePath) {
+		auto *directoryPaths = new std::vector<std::string>();
 
 		for (const std::filesystem::directory_entry &directoryEntry : std::filesystem::directory_iterator(System::GetWorkingDirectory() + filePath)) {
-			if (directoryEntry.is_directory()) { directoryPaths.emplace_back(directoryEntry.path().filename().generic_string()); }
+			if (directoryEntry.is_directory()) { directoryPaths->emplace_back(directoryEntry.path().filename().generic_string()); }
 		}
 		return directoryPaths;
 	}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	const std::vector<std::string> & LuaMan::FileList(const std::string &filePath) {
-		thread_local std::vector<std::string> filePaths;
-		filePaths.clear();
+	const std::vector<std::string> * LuaMan::FileList(const std::string &filePath) {
+		auto *filePaths = new std::vector<std::string>();
 
 		for (const std::filesystem::directory_entry &directoryEntry : std::filesystem::directory_iterator(System::GetWorkingDirectory() + filePath)) {
-			if (directoryEntry.is_regular_file()) { filePaths.emplace_back(directoryEntry.path().filename().generic_string()); }
+			if (directoryEntry.is_regular_file()) { filePaths->emplace_back(directoryEntry.path().filename().generic_string()); }
 		}
 		return filePaths;
 	}

--- a/Managers/LuaMan.h
+++ b/Managers/LuaMan.h
@@ -284,8 +284,8 @@ namespace RTE {
 		double PosRand();
 
 #pragma region Passthrough LuaMan Functions
-		const std::vector<std::string>& DirectoryList(const std::string& relativeDirectory);
-		const std::vector<std::string>& FileList(const std::string& relativeDirectory);
+		const std::vector<std::string>* DirectoryList(const std::string& relativeDirectory);
+		const std::vector<std::string>* FileList(const std::string& relativeDirectory);
 		bool FileExists(const std::string &fileName);
 		int FileOpen(const std::string& fileName, const std::string& accessMode);
 		void FileClose(int fileIndex);
@@ -433,7 +433,7 @@ namespace RTE {
 		/// </summary>
 		/// <param name="relativeDirectory">Directory path relative to the working directory.</param>
 		/// <returns>A vector of the directories in relativeDirectory.</returns>
-		const std::vector<std::string> & DirectoryList(const std::string &relativeDirectory);
+		const std::vector<std::string> * DirectoryList(const std::string &relativeDirectory);
 
 		/// <summary>
 		/// Returns a vector of all the files in relativeDirectory, which is relative to the working directory.
@@ -441,7 +441,7 @@ namespace RTE {
 		/// </summary>
 		/// <param name="relativeDirectory">Directory path relative to the working directory.</param>
 		/// <returns>A vector of the files in relativeDirectory.</returns>
-		const std::vector<std::string> & FileList(const std::string &relativeDirectory);
+		const std::vector<std::string> * FileList(const std::string &relativeDirectory);
 
 		/// <summary>
 		/// Returns whether or not the specified file exists. You can only check for files inside .rte folders in the working directory.


### PR DESCRIPTION
When `GetDirectoryList()` or `GetFileList()` were called recursively, the inner call would overwrite the data from the outer call. This is very bad, of course. So I made them reentrant, based on the already reentrant `GetWounds()` that also returns a `std::vector`.

I also made a minimal reproducible example [mod](https://github.com/cortex-command-community/Cortex-Command-Community-Project/files/13837697/bug.rte.zip) to demonstrate how this PR changes the list functions their behavior.