### PR TITLE
Use correct MAG filter for GL texture

### DIFF
--- a/Source/Managers/PostProcessMan.cpp
+++ b/Source/Managers/PostProcessMan.cpp
@@ -159,7 +159,7 @@ namespace RTE {
 		glBindTexture(GL_TEXTURE_2D, reinterpret_cast<GLBitmapInfo*>(bitmap->extra)->m_Texture);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bitmap->w, bitmap->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, bitmap->line[0]);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glGenerateMipmap(GL_TEXTURE_2D);
 	}
 


### PR DESCRIPTION
Miscopy from MIN filter, which accepts wider variety of options.

MAG filter only accepts GL_LINEAR and GL_NEAREST.