### PR TITLE
Early return when full path exists on Linux

### DIFF
--- a/Source/Managers/LuaMan.cpp
+++ b/Source/Managers/LuaMan.cpp
@@ -1043,6 +1043,10 @@ namespace RTE {
 			FILE *file = fopen(fullPath.c_str(), accessMode.c_str());
 #else
 			FILE *file = [&fullPath, &accessMode]() -> FILE* {
+				if (std::filesystem::exists(fullPath)) {
+					return fopen(fullPath.c_str(), accessMode.c_str());
+				}
+
 				std::filesystem::path inspectedPath = System::GetWorkingDirectory();
 				const std::filesystem::path relativeFilePath = std::filesystem::path(fullPath).lexically_relative(inspectedPath);
 

--- a/Source/System/RTETools.cpp
+++ b/Source/System/RTETools.cpp
@@ -222,6 +222,10 @@ namespace RTE {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	std::string GetCaseInsensitiveFullPath(const std::string &fullPath) {
+		if (std::filesystem::exists(fullPath)) {
+			return fullPath;
+		}
+
 		std::filesystem::path inspectedPath = System::GetWorkingDirectory();
 		const std::filesystem::path relativeFilePath = std::filesystem::path(fullPath).lexically_relative(inspectedPath);
 


### PR DESCRIPTION
> Perf concerns about how many io operations are required for getting the proper path, but ah well, not much choice I guess

I was planning to, but forgot to add an early return on Linux when the full path is already known to exist.