### PR TITLE
Let filesystem functions be slightly less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `GameActivity::LockControlledActor` Lua function to allow grab player input in the way menus (buy menu/full inventorymenu) do.
 
-- New `LuaMan` Lua I/O functions `DirectoryCreate`, `FileExists`, `DirectoryExists`, `FileRemove`, `DirectoryRemove`, `FileRename`, `DirectoryRename` and `IsValidModulePath`.
+- New `LuaMan` Lua I/O functions `DirectoryCreate`, `FileExists`, `DirectoryExists`, `FileRemove`, `DirectoryRemove`, `FileRename` and `DirectoryRename`.
 
 - New `FrameMan` Lua functions `SetHudDisabled(disabled, screenId)` and `IsHudDisabled(screenId)` that allows disabling a given screen's HUD, and checking whether it's currently disabled. The screenId parameters are optional and default to screen 0.
 

--- a/Source/Managers/LuaMan.cpp
+++ b/Source/Managers/LuaMan.cpp
@@ -78,7 +78,6 @@ void LuaStateWrapper::Initialize() {
 	                             .def("GetFileList", &LuaStateWrapper::FileList, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
 	                             .def("FileExists", &LuaStateWrapper::FileExists)
 	                             .def("DirectoryExists", &LuaStateWrapper::DirectoryExists)
-	                             .def("IsValidModulePath", &LuaStateWrapper::IsValidModulePath)
 	                             .def("FileOpen", &LuaStateWrapper::FileOpen)
 	                             .def("FileClose", &LuaStateWrapper::FileClose)
 	                             .def("FileRemove", &LuaStateWrapper::FileRemove)
@@ -278,7 +277,6 @@ const std::vector<std::string>* LuaStateWrapper::DirectoryList(const std::string
 const std::vector<std::string>* LuaStateWrapper::FileList(const std::string& path) { return g_LuaMan.FileList(path); }
 bool LuaStateWrapper::FileExists(const std::string& path) { return g_LuaMan.FileExists(path); }
 bool LuaStateWrapper::DirectoryExists(const std::string& path) { return g_LuaMan.DirectoryExists(path); }
-bool LuaStateWrapper::IsValidModulePath(const std::string& path) { return g_LuaMan.IsValidModulePath(path); }
 int LuaStateWrapper::FileOpen(const std::string& path, const std::string& accessMode) { return g_LuaMan.FileOpen(path, accessMode); }
 void LuaStateWrapper::FileClose(int fileIndex) { return g_LuaMan.FileClose(fileIndex); }
 void LuaStateWrapper::FileCloseAll() { return g_LuaMan.FileCloseAll(); }
@@ -885,17 +883,17 @@ LuaMan::~LuaMan() {
 }
 
 const std::vector<std::string>* LuaMan::DirectoryList(const std::string& path) {
-	std::string fullPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(path);
+	std::string fullPath = System::GetWorkingDirectory() + path;
 	auto* directoryPaths = new std::vector<std::string>();
 
-	if (IsValidModulePath(fullPath)) {
+	if (fullPath.find("..") == std::string::npos) {
 #ifndef _WIN32
 		fullPath = GetCaseInsensitiveFullPath(fullPath);
 #endif
 		if (std::filesystem::exists(fullPath)) {
-			for (const std::filesystem::directory_entry& directoryEntry: std::filesystem::directory_iterator(fullPath)) {
-				if (directoryEntry.is_directory()) {
-					directoryPaths->emplace_back(directoryEntry.path().filename().generic_string());
+			for (const auto& entry: std::filesystem::directory_iterator(fullPath)) {
+				if (entry.is_directory()) {
+					directoryPaths->emplace_back(entry.path().filename().generic_string());
 				}
 			}
 		}
@@ -904,17 +902,17 @@ const std::vector<std::string>* LuaMan::DirectoryList(const std::string& path) {
 }
 
 const std::vector<std::string>* LuaMan::FileList(const std::string& path) {
-	std::string fullPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(path);
+	std::string fullPath = System::GetWorkingDirectory() + path;
 	auto* filePaths = new std::vector<std::string>();
 
-	if (IsValidModulePath(fullPath)) {
+	if (fullPath.find("..") == std::string::npos) {
 #ifndef _WIN32
 		fullPath = GetCaseInsensitiveFullPath(fullPath);
 #endif
 		if (std::filesystem::exists(fullPath)) {
-			for (const std::filesystem::directory_entry& directoryEntry: std::filesystem::directory_iterator(fullPath)) {
-				if (directoryEntry.is_regular_file()) {
-					filePaths->emplace_back(directoryEntry.path().filename().generic_string());
+			for (const auto& entry: std::filesystem::directory_iterator(fullPath)) {
+				if (entry.is_regular_file()) {
+					filePaths->emplace_back(entry.path().filename().generic_string());
 				}
 			}
 		}
@@ -924,7 +922,7 @@ const std::vector<std::string>* LuaMan::FileList(const std::string& path) {
 
 bool LuaMan::FileExists(const std::string& path) {
 	std::string fullPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(path);
-	if (IsValidModulePath(fullPath)) {
+	if (fullPath.find("..") == std::string::npos) {
 #ifndef _WIN32
 		fullPath = GetCaseInsensitiveFullPath(fullPath);
 #endif
@@ -935,7 +933,7 @@ bool LuaMan::FileExists(const std::string& path) {
 
 bool LuaMan::DirectoryExists(const std::string& path) {
 	std::string fullPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(path);
-	if (IsValidModulePath(fullPath)) {
+	if (fullPath.find("..") == std::string::npos) {
 #ifndef _WIN32
 		fullPath = GetCaseInsensitiveFullPath(fullPath);
 #endif
@@ -1049,7 +1047,7 @@ bool LuaMan::FileRemove(const std::string& path) {
 
 bool LuaMan::DirectoryCreate(const std::string& path, bool recursive) {
 	std::string fullPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(path);
-	if (IsValidModulePath(fullPath)) {
+	if (fullPath.find("..") == std::string::npos) {
 #ifndef _WIN32
 		fullPath = GetCaseInsensitiveFullPath(fullPath);
 #endif
@@ -1067,7 +1065,7 @@ bool LuaMan::DirectoryCreate(const std::string& path, bool recursive) {
 
 bool LuaMan::DirectoryRemove(const std::string& path, bool recursive) {
 	std::string fullPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(path);
-	if (IsValidModulePath(fullPath)) {
+	if (fullPath.find("..") == std::string::npos) {
 #ifndef _WIN32
 		fullPath = GetCaseInsensitiveFullPath(fullPath);
 #endif
@@ -1109,7 +1107,7 @@ bool LuaMan::FileRename(const std::string& oldPath, const std::string& newPath) 
 bool LuaMan::DirectoryRename(const std::string& oldPath, const std::string& newPath) {
 	std::string fullOldPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(oldPath);
 	std::string fullNewPath = System::GetWorkingDirectory() + g_PresetMan.GetFullModulePath(newPath);
-	if (IsValidModulePath(fullOldPath) && IsValidModulePath(fullNewPath)) {
+	if (fullOldPath.find("..") == std::string::npos && fullNewPath.find("..") == std::string::npos) {
 #ifndef _WIN32
 		fullOldPath = GetCaseInsensitiveFullPath(fullOldPath);
 		fullNewPath = GetCaseInsensitiveFullPath(fullNewPath);

--- a/Source/Managers/LuaMan.h
+++ b/Source/Managers/LuaMan.h
@@ -214,7 +214,6 @@ namespace RTE {
 		const std::vector<std::string>* FileList(const std::string& path);
 		bool FileExists(const std::string& path);
 		bool DirectoryExists(const std::string& path);
-		bool IsValidModulePath(const std::string& path);
 		int FileOpen(const std::string& path, const std::string& accessMode);
 		void FileClose(int fileIndex);
 		void FileCloseAll();


### PR DESCRIPTION
So the timeline of events is that:
1. My original implementation of `DirectoryList()` forgot the logic that disallows escaping the game's directory.
2. I noticed this, and panicked so hard that I let my recent filesystem functions PR disallow mods from doing anything outside of their directory, just to be safe.
3. Today I tried to actually use my new filesystem functions in ModMod, and quickly noticed that my mod entirely broke, since it wasn't able to iterate over the entries in `Data/` or `Mods/` anymore. I also realized that loads of functionality I am still planning to add, like being able to create or rename mod directories in-game, was now entirely impossible. But there isn't anything fundamentally unsafe with these things!

So, this PR finds a good middle ground, where the game's directory still can't be escaped, and shenanigans like editing the game executable's bytes still isn't allowed, but safe operations like iterating over/creating/moving directories around is now allowed.

I also got rid of the `IsValidModulePath()` binding, since I realized that I don't think I'd ever even find a use for it myself, as you'd always want to either specifically use either `FileExists()` or `DirectoryExists()` instead in practice. A binding for it could always be added back later, if someone finds a use for it.