### PR TITLE
Added CastTerrainPenetrationRay to SceneMan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Exposed `FrameMan` properties `ScreenCount` and `ResolutionMultiplier` to Lua (R).
 
+- New `SceneMan` Lua function `CastTerrainPenetrationRay(Vector start, Vector ray, Vector endPos, int strengthLimit, int skip)`, which adds up the material strength of the terrain pixels encountered along the way, and stops when the accumulated value meets or exceeds `strengthLimit`. `endPos` is filled out with the ending position of the ray, returns `true` or `false` depending on whether the ray was stopped early or not.
+
 </details>
 
 <details><summary><b>Changed</b></summary>

--- a/Source/Lua/LuaBindingsManagers.cpp
+++ b/Source/Lua/LuaBindingsManagers.cpp
@@ -314,6 +314,7 @@ LuaBindingRegisterFunctionDefinitionForType(ManagerLuaBindings, SceneMan) {
 	    .def("CastMORay", &SceneMan::CastMORay)
 	    .def("CastFindMORay", &SceneMan::CastFindMORay)
 	    .def("CastObstacleRay", &SceneMan::CastObstacleRay)
+	    .def("CastTerrainPenetrationRay", &SceneMan::CastTerrainPenetrationRay)
 	    .def("GetLastRayHitPos", &SceneMan::GetLastRayHitPos)
 	    .def("FindAltitude", (float(SceneMan::*)(const Vector&, int, int)) & SceneMan::FindAltitude)
 	    .def("FindAltitude", (float(SceneMan::*)(const Vector&, int, int, bool)) & SceneMan::FindAltitude)

--- a/Source/Managers/SceneMan.h
+++ b/Source/Managers/SceneMan.h
@@ -460,6 +460,18 @@ namespace RTE {
 		/// @param width The team to restore for.
 		void RestoreUnseenBox(const int posX, const int posY, const int width, const int height, const int team);
 
+		/// Traces along a vector and stops when the accumulated material strengths of the
+		/// traced-through terrain meets or exceeds a given value.
+		/// @param start The starting position.
+		/// @param ray The vector to trace along.
+		/// @param endPos A Vector that will be set to the position of where the sight ray was
+		/// terminated. If it reached the end, it will be set to the end of the ray.
+		/// @param strengthLimit The accumulated material strength limit where the ray stops.
+		/// @param skip For every pixel checked along the line, how many to skip between them
+		/// for optimization reasons. 0 = every pixel is checked.
+		/// @return Whether the ray was stopped prematurely or not.
+		bool CastTerrainPenetrationRay(const Vector& start, const Vector& ray, Vector& endPos, int strengthLimit, int skip);
+
 		/// Traces along a vector and reveals or hides pixels on the unseen layer of a team
 		/// as long as the accumulated material strengths traced through the terrain
 		/// don't exceed a specific value.


### PR DESCRIPTION
Added CastTerrainPenetrationRay to SceneMan, which stops after passing through a given amount of terrain material strength and returns true if stopped. This functionality is mostly already present in CastUnseenRay and all its siblings, but they all affect fog of war, so i figured it was nice to have this functionality without messing with fog of war.