### PR TITLE
Exposed MOPixel Color to Lua, made DislodgePixel return MOPixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `SceneMan` Lua function `CastTerrainPenetrationRay(Vector start, Vector ray, Vector endPos, int strengthLimit, int skip)`, which adds up the material strength of the terrain pixels encountered along the way, and stops when the accumulated value meets or exceeds `strengthLimit`. `endPos` is filled out with the ending position of the ray, returns `true` or `false` depending on whether the ray was stopped early or not.
 
+- Exposed `MOPixel` property `Color` to Lua. It gets and sets the index of the MOPixel's color.
+
 </details>
 
 <details><summary><b>Changed</b></summary>
@@ -177,6 +179,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The `SceneObject` property `IsBuyable` has been renamed to `Buyable`.
 
 - `SceneMan` Lua function `DislodgePixel()` now optionally accepts a third boolean argument to delete the found pixel immediately. Format is `DislodgePixel(int posX, int posY, bool deletePixel)`. `DislodgePixel()` now also automatically accounts for scene wrapping.
+
+- `SceneMan` Lua function `DislodgePixel()` and all of its derivatives now return `MOPixel` instead of `MovableObject` to save on typecasting in Lua.
 
 </details>
 

--- a/Source/Entities/MOPixel.h
+++ b/Source/Entities/MOPixel.h
@@ -86,9 +86,17 @@ namespace RTE {
 		/// @return A Color object describing the color.
 		Color GetColor() const { return m_Color; }
 
+		/// Gets the index of the color of this MOPixel.
+		/// @return An int that is the index of the Color object.
+		int GetColorIndex() const { return m_Color.GetIndex(); }
+
 		/// Sets the color value of this MOPixel.
 		/// @param newColor A Color object specifying the new color index value.
 		void SetColor(Color newColor) { m_Color = newColor; }
+
+		/// Sets the color value of this MOPixel via index.
+		/// @param newColor An int specifying the new color index value.
+		void SetColorIndex(int newColorIndex) { m_Color.SetRGBWithIndex(newColorIndex); }
 
 		/// Travel distance until the bullet start to lose lethality.
 		/// @return The factor that modifies the base value.

--- a/Source/Lua/LuaBindingsEntities.cpp
+++ b/Source/Lua/LuaBindingsEntities.cpp
@@ -763,7 +763,8 @@ LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, MOPixel) {
 	return ConcreteTypeLuaClassDefinition(MOPixel, MovableObject)
 
 	    .property("TrailLength", &MOPixel::GetTrailLength, &MOPixel::SetTrailLength)
-	    .property("Staininess", &MOPixel::GetStaininess, &MOPixel::SetStaininess);
+	    .property("Staininess", &MOPixel::GetStaininess, &MOPixel::SetStaininess)
+	    .property("Color", &MOPixel::GetColorIndex, &MOPixel::SetColorIndex);
 }
 
 LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, MOSParticle) {

--- a/Source/Lua/LuaBindingsManagers.cpp
+++ b/Source/Lua/LuaBindingsManagers.cpp
@@ -333,14 +333,14 @@ LuaBindingRegisterFunctionDefinitionForType(ManagerLuaBindings, SceneMan) {
 	    .def("CheckAndRemoveOrphans", (int(SceneMan::*)(int, int, int, int, bool)) & SceneMan::RemoveOrphans)
 	    .def("DislodgePixel", &SceneMan::DislodgePixel)
 	    .def("DislodgePixel", &SceneMan::DislodgePixelBool)
-	    .def("DislodgePixelLine", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& start, const Vector& ray, int skip, bool deletePixels) const) & SceneMan::DislodgePixelLine, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
-	    .def("DislodgePixelLine", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& start, const Vector& ray, int skip) const) & SceneMan::DislodgePixelLineNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
-	    .def("DislodgePixelCircle", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& centre, float radius, bool deletePixels) const) & SceneMan::DislodgePixelCircle, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
-	    .def("DislodgePixelCircle", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& centre, float radius) const) & SceneMan::DislodgePixelCircleNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
-	    .def("DislodgePixelBox", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& upperLeftCorner, const Vector& lowerRightCorner, bool deletePixels) const) & SceneMan::DislodgePixelBox, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
-	    .def("DislodgePixelBox", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& upperLeftCorner, const Vector& lowerRightCorner) const) & SceneMan::DislodgePixelBoxNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
-	    .def("DislodgePixelRing", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& centre, float innerRadius, float outerRadius, bool deletePixels) const) & SceneMan::DislodgePixelRing, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
-	    .def("DislodgePixelRing", (const std::vector<MovableObject*>* (SceneMan::*)(const Vector& centre, float innerRadius, float outerRadius) const) & SceneMan::DislodgePixelRingNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator);
+	    .def("DislodgePixelLine", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& start, const Vector& ray, int skip, bool deletePixels) const) & SceneMan::DislodgePixelLine, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+	    .def("DislodgePixelLine", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& start, const Vector& ray, int skip) const) & SceneMan::DislodgePixelLineNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+	    .def("DislodgePixelCircle", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& centre, float radius, bool deletePixels) const) & SceneMan::DislodgePixelCircle, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+	    .def("DislodgePixelCircle", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& centre, float radius) const) & SceneMan::DislodgePixelCircleNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+	    .def("DislodgePixelBox", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& upperLeftCorner, const Vector& lowerRightCorner, bool deletePixels) const) & SceneMan::DislodgePixelBox, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+	    .def("DislodgePixelBox", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& upperLeftCorner, const Vector& lowerRightCorner) const) & SceneMan::DislodgePixelBoxNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+	    .def("DislodgePixelRing", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& centre, float innerRadius, float outerRadius, bool deletePixels) const) & SceneMan::DislodgePixelRing, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator)
+	    .def("DislodgePixelRing", (const std::vector<MOPixel*>* (SceneMan::*)(const Vector& centre, float innerRadius, float outerRadius) const) & SceneMan::DislodgePixelRingNoBool, luabind::adopt(luabind::return_value) + luabind::return_stl_iterator);
 }
 
 LuaBindingRegisterFunctionDefinitionForType(ManagerLuaBindings, CameraMan) {

--- a/Source/Managers/SceneMan.cpp
+++ b/Source/Managers/SceneMan.cpp
@@ -892,7 +892,7 @@ bool SceneMan::TryPenetrate(int posX,
 	return false;
 }
 
-MovableObject* SceneMan::DislodgePixel(int posX, int posY) {
+MOPixel* SceneMan::DislodgePixel(int posX, int posY) {
 	WrapPosition(posX, posY);
 	int materialID = getpixel(m_pCurrentScene->GetTerrain()->GetMaterialBitmap(), posX, posY);
 	if (materialID <= MaterialColorKeys::g_MaterialAir) {
@@ -924,16 +924,16 @@ MovableObject* SceneMan::DislodgePixel(int posX, int posY) {
 }
 
 // Bool variant to avoid changing the original
-MovableObject* SceneMan::DislodgePixelBool(int posX, int posY, bool deletePixel) {
-	MovableObject* pixelMO = DislodgePixel(posX, posY);
+MOPixel* SceneMan::DislodgePixelBool(int posX, int posY, bool deletePixel) {
+	MOPixel* pixelMO = DislodgePixel(posX, posY);
 	if (pixelMO) {
 		pixelMO->SetToDelete(deletePixel);
 	}
 	return pixelMO;
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelCircle(const Vector& centre, float radius, bool deletePixels) {
-	std::vector<MovableObject*>* pixelList = new std::vector<MovableObject*>();
+std::vector<MOPixel*>* SceneMan::DislodgePixelCircle(const Vector& centre, float radius, bool deletePixels) {
+	std::vector<MOPixel*>* pixelList = new std::vector<MOPixel*>();
 	int limit = static_cast<int>(radius) * 2;
 	for (int x = 0; x <= limit; x++) {
 		for (int y = 0; y <= limit; y++) {
@@ -945,7 +945,7 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelCircle(const Vector& centre,
 			}
 
 			if (!distance.MagnitudeIsGreaterThan(radius)) {
-				MovableObject* px = DislodgePixelBool(checkPos.m_X, checkPos.m_Y, deletePixels);
+				MOPixel* px = DislodgePixelBool(checkPos.m_X, checkPos.m_Y, deletePixels);
 				if (px) {
 					pixelList->push_back(px);
 				}
@@ -956,17 +956,17 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelCircle(const Vector& centre,
 	return pixelList;
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelCircleNoBool(const Vector& centre, float radius) {
+std::vector<MOPixel*>* SceneMan::DislodgePixelCircleNoBool(const Vector& centre, float radius) {
 	return DislodgePixelCircle(centre, radius, false);
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelRing(const Vector& centre, float innerRadius, float outerRadius, bool deletePixels) {
+std::vector<MOPixel*>* SceneMan::DislodgePixelRing(const Vector& centre, float innerRadius, float outerRadius, bool deletePixels) {
 	// Account for users inputting radii in the wrong order
 	if (outerRadius < innerRadius) {
 		std::swap(outerRadius, innerRadius);
 	}
 
-	std::vector<MovableObject*>* pixelList = new std::vector<MovableObject*>();
+	std::vector<MOPixel*>* pixelList = new std::vector<MOPixel*>();
 	int limit = static_cast<int>(outerRadius) * 2;
 	for (int x = 0; x <= limit; x++) {
 		for (int y = 0; y <= limit; y++) {
@@ -983,7 +983,7 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelRing(const Vector& centre, f
 			}
 
 			if (!distance.MagnitudeIsGreaterThan(outerRadius) && !distance.MagnitudeIsLessThan(innerRadius)) {
-				MovableObject* px = DislodgePixelBool(checkPos.m_X, checkPos.m_Y, deletePixels);
+				MOPixel* px = DislodgePixelBool(checkPos.m_X, checkPos.m_Y, deletePixels);
 				if (px) {
 					pixelList->push_back(px);
 				}
@@ -994,12 +994,12 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelRing(const Vector& centre, f
 	return pixelList;
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelRingNoBool(const Vector& centre, float innerRadius, float outerRadius) {
+std::vector<MOPixel*>* SceneMan::DislodgePixelRingNoBool(const Vector& centre, float innerRadius, float outerRadius) {
 	return DislodgePixelRing(centre, innerRadius, outerRadius, false);
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelBox(const Vector& upperLeftCorner, const Vector& lowerRightCorner, bool deletePixels) {
-	std::vector<MovableObject*>* pixelList = new std::vector<MovableObject*>();
+std::vector<MOPixel*>* SceneMan::DislodgePixelBox(const Vector& upperLeftCorner, const Vector& lowerRightCorner, bool deletePixels) {
+	std::vector<MOPixel*>* pixelList = new std::vector<MOPixel*>();
 
 	// Make sure it works even if people input corners in the wrong order
 	Vector start = Vector(std::min(upperLeftCorner.m_X, lowerRightCorner.m_X), std::min(upperLeftCorner.m_Y, lowerRightCorner.m_Y));
@@ -1010,7 +1010,7 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelBox(const Vector& upperLeftC
 	for (int x = 0; x <= static_cast<int>(width) * 2; x++) {
 		for (int y = 0; y <= static_cast<int>(height) * 2; y++) {
 			Vector checkPos = start + Vector(static_cast<float>(x), static_cast<float>(y));
-			MovableObject* px = DislodgePixelBool(checkPos.m_X, checkPos.m_Y, deletePixels);
+			MOPixel* px = DislodgePixelBool(checkPos.m_X, checkPos.m_Y, deletePixels);
 			if (px) {
 				pixelList->push_back(px);
 			}
@@ -1020,12 +1020,12 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelBox(const Vector& upperLeftC
 	return pixelList;
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelBoxNoBool(const Vector& upperLeftCorner, const Vector& lowerRightCorner) {
+std::vector<MOPixel*>* SceneMan::DislodgePixelBoxNoBool(const Vector& upperLeftCorner, const Vector& lowerRightCorner) {
 	return DislodgePixelBox(upperLeftCorner, lowerRightCorner, false);
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelLine(const Vector& start, const Vector& ray, int skip, bool deletePixels) {
-	std::vector<MovableObject*>* pixelList = new std::vector<MovableObject*>();
+std::vector<MOPixel*>* SceneMan::DislodgePixelLine(const Vector& start, const Vector& ray, int skip, bool deletePixels) {
+	std::vector<MOPixel*>* pixelList = new std::vector<MOPixel*>();
 	int error, dom, sub, domSteps, skipped = skip;
 	int intPos[2], delta[2], delta2[2], increment[2];
 
@@ -1080,7 +1080,7 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelLine(const Vector& start, co
 			// Scene wrapping
 			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
 
-			MovableObject* px = DislodgePixelBool(intPos[X], intPos[Y], deletePixels);
+			MOPixel* px = DislodgePixelBool(intPos[X], intPos[Y], deletePixels);
 			if (px) {
 				pixelList->push_back(px);
 			}
@@ -1093,7 +1093,7 @@ std::vector<MovableObject*>* SceneMan::DislodgePixelLine(const Vector& start, co
 	return pixelList;
 }
 
-std::vector<MovableObject*>* SceneMan::DislodgePixelLineNoBool(const Vector& start, const Vector& ray, int skip) {
+std::vector<MOPixel*>* SceneMan::DislodgePixelLineNoBool(const Vector& start, const Vector& ray, int skip) {
 	return DislodgePixelLine(start, ray, skip, false);
 }
 

--- a/Source/Managers/SceneMan.h
+++ b/Source/Managers/SceneMan.h
@@ -401,27 +401,27 @@ namespace RTE {
 		/// @param posX The X coordinate of the terrain pixel.
 		/// @param posX The Y coordinate of the terrain pixel.
 		/// @return The newly dislodged pixel, if one was found.
-		MovableObject* DislodgePixel(int posX, int posY);
+		MOPixel* DislodgePixel(int posX, int posY);
 
 		/// Removes a pixel from the terrain and adds it to MovableMan.
 		/// @param posX The X coordinate of the terrain pixel.
 		/// @param posX The Y coordinate of the terrain pixel.
 		/// @param deletePixel Whether or not to immediately mark the pixel for deletion.
 		/// @return The newly dislodged pixel, if one was found.
-		MovableObject* DislodgePixelBool(int posX, int posY, bool deletePixel);
+		MOPixel* DislodgePixelBool(int posX, int posY, bool deletePixel);
 
 		/// Removes a circle of pixels from the terrain and adds them to MovableMan.
 		/// @param centre The vector position of the centre of the circle.
 		/// @param radius The radius of the circle of pixels to remove.
 		/// @param deletePixels Whether or not to immediately mark all found pixels for deletion.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelCircle(const Vector& centre, float radius, bool deletePixels);
+		std::vector<MOPixel*>* DislodgePixelCircle(const Vector& centre, float radius, bool deletePixels);
 
 		/// Removes a circle of pixels from the terrain and adds them to MovableMan.
 		/// @param centre The vector position of the centre of the circle.
 		/// @param radius The radius of the circle of pixels to remove.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelCircleNoBool(const Vector& centre, float radius);
+		std::vector<MOPixel*>* DislodgePixelCircleNoBool(const Vector& centre, float radius);
 
 		/// Removes a ring of pixels from the terrain and adds them to MovableMan.
 		/// @param centre The vector position of the centre of the ring.
@@ -429,27 +429,27 @@ namespace RTE {
 		/// @param outerRadius The outer radius of the ring of pixels to remove.
 		/// @param deletePixels Whether or not to immediately mark all found pixels for deletion.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelRing(const Vector& centre, float innerRadius, float outerRadius, bool deletePixels);
+		std::vector<MOPixel*>* DislodgePixelRing(const Vector& centre, float innerRadius, float outerRadius, bool deletePixels);
 
 		/// Removes a ring of pixels from the terrain and adds them to MovableMan.
 		/// @param centre The vector position of the centre of the ring.
 		/// @param innerRadius The inner radius of the ring of pixels to remove.
 		/// @param outerRadius The outer radius of the ring of pixels to remove.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelRingNoBool(const Vector& centre, float innerRadius, float outerRadius);
+		std::vector<MOPixel*>* DislodgePixelRingNoBool(const Vector& centre, float innerRadius, float outerRadius);
 
 		/// Removes a box of pixels from the terrain and adds them to MovableMan.
 		/// @param upperLeftCorner The vector position of the upper left corner of the box.
 		/// @param lowerRightCorner The vector position of the lower right corner of the box.
 		/// @param deletePixels Whether or not to immediately mark all found pixels for deletion.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelBox(const Vector& upperLeftCorner, const Vector& lowerRightCorner, bool deletePixels);
+		std::vector<MOPixel*>* DislodgePixelBox(const Vector& upperLeftCorner, const Vector& lowerRightCorner, bool deletePixels);
 
 		/// Removes a box of pixels from the terrain and adds them to MovableMan.
 		/// @param upperLeftCorner The vector position of the upper left corner of the box.
 		/// @param lowerRightCorner The vector position of the lower right corner of the box.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelBoxNoBool(const Vector& upperLeftCorner, const Vector& lowerRightCorner);
+		std::vector<MOPixel*>* DislodgePixelBoxNoBool(const Vector& upperLeftCorner, const Vector& lowerRightCorner);
 
 		/// Removes a line of pixels from the terrain and adds them to MovableMan.
 		/// @param start The starting position.
@@ -457,14 +457,14 @@ namespace RTE {
 		/// @param skip For every pixel checked along the line, how many to skip between them.
 		/// @param deletePixels Whether or not to immediately mark all found pixels for deletion.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelLine(const Vector& start, const Vector& ray, int skip, bool deletePixels);
+		std::vector<MOPixel*>* DislodgePixelLine(const Vector& start, const Vector& ray, int skip, bool deletePixels);
 
 		/// Removes a line of pixels from the terrain and adds them to MovableMan.
 		/// @param start The starting position.
 		/// @param ray The vector to trace along.
 		/// @param skip For every pixel checked along the line, how many to skip between them.
 		/// @return A list of the removed pixels, if any.
-		std::vector<MovableObject*>* DislodgePixelLineNoBool(const Vector& start, const Vector& ray, int skip);
+		std::vector<MOPixel*>* DislodgePixelLineNoBool(const Vector& start, const Vector& ray, int skip);
 
 		/// Sets one team's view of the scene to be unseen, using a generated map
 		/// of a specific resolution chunkiness.


### PR DESCRIPTION
Enabled Color changes of `MOPixels` on the fly with Lua, using two new methods to specifically get and set the index of the MOPixel's color directly. Additionally, changed `DislodgePixel` and all of its new derivatives to return `MOPixel` instead of `MovableObject`, because what else would it possibly return?