### PR TITLE
Fix nucleo shots breaking if loading mid-explosion-sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Reverted a change to pathfinding, that although was technically accurate, caused issues with the AI being too eager to path up-and-over obstacles instead of through them. In the future this will likely be revisited when we get jump-aware pathfinding.
 
+- Fixed nucleo shots breaking if saving and loading them mid explosion sequence.
+
 </details>
 
 <details><summary><b>Removed</b></summary>

--- a/Data/Techion.rte/Devices/Weapons/Nucleo/NucleoShot.lua
+++ b/Data/Techion.rte/Devices/Weapons/Nucleo/NucleoShot.lua
@@ -19,7 +19,7 @@ function Explode(self)
 			melter.Pos = self.Pos;
 			melter.Team = self.Team;
 			melter.Sharpness = ToActor(parent).ID;
-			melter.PinStrength = self.disintegrationStrength * math.sqrt(math.max(1, #self.connectableParticles));
+			melter.PinStrength = self.disintegrationStrength * math.sqrt(math.max(1, (self.connectableParticles and #self.connectableParticles or 1)));
 			MovableMan:AddMO(melter);
 		end
 	end
@@ -118,10 +118,12 @@ function ThreadedUpdate(self)
 end
 
 function SyncedUpdate(self)
-	for k, particle in pairs(self.connectableParticles) do
-		if MovableMan:ValidMO(particle) then
-			particle.Pos = self.Pos + Vector(math.random() * 5, 0):RadRotate(math.random() * math.pi * 2);
-			particle:SendMessage("Nucleo_Explode");
+	if self.connectableParticles then
+		for k, particle in pairs(self.connectableParticles) do
+			if MovableMan:ValidMO(particle) then
+				particle.Pos = self.Pos + Vector(math.random() * 5, 0):RadRotate(math.random() * math.pi * 2);
+				particle:SendMessage("Nucleo_Explode");
+			end
 		end
 	end
 

--- a/Data/Techion.rte/Devices/Weapons/Nucleo/NucleoShot.lua
+++ b/Data/Techion.rte/Devices/Weapons/Nucleo/NucleoShot.lua
@@ -54,6 +54,7 @@ end
 
 function Create(self)
 	self.detTimer = Timer();
+	self.detDelay = 1000;
 	self.boom = false;
 
 	self.speed = 15;


### PR DESCRIPTION
Give them a few defaults to some variables that disappear when save/loading

It's not really worth it bringing in SaveLoadHandler and saving all this stuff properly, because something in the middle of an explosion sequence is... about to explode anyway