### PR TITLE
Fix Dummy Assault always resetting funds even on loading games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Reverted a change to pathfinding, that although was technically accurate, caused issues with the AI being too eager to path up-and-over obstacles instead of through them. In the future this will likely be revisited when we get jump-aware pathfinding.
 
+- Fixed Dummy Assault resetting funds to their initial value upon loading a saved game.
+
 </details>
 
 <details><summary><b>Removed</b></summary>

--- a/Data/Missions.rte/Activities/DummyAssault.lua
+++ b/Data/Missions.rte/Activities/DummyAssault.lua
@@ -13,8 +13,6 @@ function DummyAssault:StartActivity(isNewGame)
 	self.CPUTeam = Activity.TEAM_2;
 	self.CPUTech = self:GetTeamTech(Activity.TEAM_2);
 
-	self:SetTeamFunds(self:GetStartingGold(), Activity.TEAM_1);
-
 	if isNewGame then
 		self:StartNewGame();
 	else


### PR DESCRIPTION
Was just one erroneous line that always ran in StartActivity instead of only in StartNewGame