### PR TITLE
Activities: Be more consistent about passing screens, some fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+<details><summary><b>Changed</b></summary>
+
+- Massacre now displays the remaining kill count to each player's screen instead of just the first one.
+
+</details>
+
+<details><summary><b>Fixed</b></summary>
+
+- Fixed instances of `FrameMan:ClearScreenText()` and `FrameMan:SetScreenText()` supplying a player index instead of a screen index. For example, "Signal Hunt" wouldn't display the Alchiral messages if you used a different player than player 1.
+
+- Fixed some activities iterating from `0` to `PlayerCount - 1` instead of iterating over every player index and filtering to active human players. For example, "Exploration" (Doainar) was unable to progress if you used a different player than player 1.
+
+</details>
+
 ## [Release v6.1.0] - 2024/02/15
 
 <details><summary><b>Added</b></summary>

--- a/Data/Base.rte/Activities/BrainVsBrain.lua
+++ b/Data/Base.rte/Activities/BrainVsBrain.lua
@@ -387,8 +387,8 @@ function BrainvsBrain:UpdateActivity()
 							end
 						else
 							self:ResetMessageTimer(player);
-							FrameMan:ClearScreenText(player);
-							FrameMan:SetScreenText("Your brain has been destroyed!", player, 2000, -1, false);
+							FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+							FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 2000, -1, false);
 						end
 					end
 				end

--- a/Data/Base.rte/Activities/Harvester.lua
+++ b/Data/Base.rte/Activities/Harvester.lua
@@ -157,9 +157,9 @@ function Harvester:UpdateActivity()
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				--Display messages.
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(self.goldNeeded - (math.ceil(self:GetTeamFunds(Activity.TEAM_1)) - self.humanTeamFundsAfterInitialEditingPhase) .. " oz of gold left", player, 0, 1000, false);
+					FrameMan:SetScreenText(self.goldNeeded - (math.ceil(self:GetTeamFunds(Activity.TEAM_1)) - self.humanTeamFundsAfterInitialEditingPhase) .. " oz of gold left", self:ScreenOfPlayer(player), 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Dig up " .. self.goldDisplay .. " oz of gold!", player, 333, 5000, true);
+					FrameMan:SetScreenText("Dig up " .. self.goldDisplay .. " oz of gold!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -179,8 +179,8 @@ function Harvester:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -191,8 +191,8 @@ function Harvester:UpdateActivity()
 				--Check if the player has won.
 				if self:GetTeamFunds(Activity.TEAM_1) - self.humanTeamFundsAfterInitialEditingPhase > self.goldNeeded then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("You dug up all the gold!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("You dug up all the gold!", self:ScreenOfPlayer(player), 333, -1, false);
 
 					self.WinnerTeam = Activity.TEAM_1;
 

--- a/Data/Base.rte/Activities/KeepieUppie.lua
+++ b/Data/Base.rte/Activities/KeepieUppie.lua
@@ -143,11 +143,11 @@ function KeepieUppie:UpdateActivity()
 				if self:PlayerActive(player) and self:PlayerHuman(player) then
 					--Display messages.
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 					if self.startMessageTimer:IsPastSimMS(3000) then
-						FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", player, 0, 1000, false);
+						FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
 					else
-						FrameMan:SetScreenText("Keep the rocket alive for " .. self.timeDisplay .. "!", player, 333, 5000, true);
+						FrameMan:SetScreenText("Keep the rocket alive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
 					end
 
 					-- The current player's team
@@ -156,8 +156,8 @@ function KeepieUppie:UpdateActivity()
 					if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 						self:SetPlayerBrain(nil, player);
 						self:ResetMessageTimer(player);
-						FrameMan:ClearScreenText(player);
-						FrameMan:SetScreenText("Your rocket has been destroyed!", player, 333, -1, false);
+						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+						FrameMan:SetScreenText("Your rocket has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 						-- Now see if all brains of self player's team are dead, and if so, end the game
 						if not MovableMan:GetFirstBrainActor(team) then
 							self.WinnerTeam = self:OtherTeam(team);
@@ -170,8 +170,8 @@ function KeepieUppie:UpdateActivity()
 					--Check if the player has won.
 					if self.winTimer:IsPastSimMS(self.timeLimit) then
 						self:ResetMessageTimer(player);
-						FrameMan:ClearScreenText(player);
-						FrameMan:SetScreenText("You survived!", player, 333, -1, false);
+						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+						FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
 
 						self.WinnerTeam = player;
 
@@ -259,7 +259,7 @@ function KeepieUppie:UpdateActivity()
 		self.startMessageTimer:Reset();
 		self.winTimer:Reset();
 
-		FrameMan:SetScreenText("Order your rocket...", Activity.PLAYER_1, 0, 5000, false);
+		FrameMan:SetScreenText("Order your rocket...", 0, 0, 5000, false);
 
 		--See if the rocket has spawned yet.
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do

--- a/Data/Base.rte/Activities/Massacre.lua
+++ b/Data/Base.rte/Activities/Massacre.lua
@@ -150,12 +150,12 @@ function Massacre:UpdateActivity()
 				--Display messages.
 				if self.startMessageTimer:IsPastSimMS(3000) then
 					if self.killsNeeded - self:GetTeamDeathCount(Activity.TEAM_2) > 1 then
-						FrameMan:SetScreenText(self.killsNeeded - self:GetTeamDeathCount(Activity.TEAM_2) .. " enemies left!", Activity.PLAYER_1, 0, 1000, false);
+						FrameMan:SetScreenText(self.killsNeeded - self:GetTeamDeathCount(Activity.TEAM_2) .. " enemies left!", self:ScreenOfPlayer(player), 0, 1000, false);
 					else
-						FrameMan:SetScreenText("1 enemy left!", Activity.PLAYER_1, 0, 1000, false);
+						FrameMan:SetScreenText("1 enemy left!", self:ScreenOfPlayer(player), 0, 1000, false);
 					end
 				else
-					FrameMan:SetScreenText("Kill " .. self.killsDisplay .. " enemies!", player, 333, 5000, true);
+					FrameMan:SetScreenText("Kill " .. self.killsDisplay .. " enemies!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -175,8 +175,8 @@ function Massacre:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -187,8 +187,8 @@ function Massacre:UpdateActivity()
 				--Check if the player has won.
 				if self:GetTeamDeathCount(Activity.TEAM_2) >= self.killsNeeded then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("You killed all the attackers!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("You killed all the attackers!", self:ScreenOfPlayer(player), 333, -1, false);
 
 					self.WinnerTeam = Activity.TEAM_1;
 

--- a/Data/Base.rte/Activities/MetaFight.lua
+++ b/Data/Base.rte/Activities/MetaFight.lua
@@ -33,7 +33,7 @@ function MetaFight:BrainCheck()
 					-- All hope is lost for this player
 					else
 						self:ResetMessageTimer(player);
---						FrameMan:ClearScreenText(player);
+--						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 --						FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 						-- Save the position of this player's brain's last known position as the last brain death position
 						self.LastBrainDeathPos = self.LastBrainPos[player];
@@ -835,7 +835,7 @@ function MetaFight:UpdateActivity()
 						self:SetObservationTarget(self:GetPlayerBrain(player).Pos, player);
 						-- Clear the messages before starting the game
 						self:ResetMessageTimer(player);
-						FrameMan:ClearScreenText(player);
+						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 						-- Reset the screen occlusion if any players are still in menus
 						CameraMan:SetScreenOcclusion(Vector(), self:ScreenOfPlayer(player));
 					end

--- a/Data/Base.rte/Activities/OneManArmy.lua
+++ b/Data/Base.rte/Activities/OneManArmy.lua
@@ -260,9 +260,9 @@ function OneManArmy:UpdateActivity()
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				--Display messages
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", player, 0, 1000, false);
+					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", player, 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
 				local team = self:GetTeamOfPlayer(player);
@@ -270,8 +270,8 @@ function OneManArmy:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 					--Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -282,8 +282,8 @@ function OneManArmy:UpdateActivity()
 				--Check if the player has won
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("You survived!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
 
 					self.WinnerTeam = player;
 

--- a/Data/Base.rte/Activities/OneManArmyDiggers.lua
+++ b/Data/Base.rte/Activities/OneManArmyDiggers.lua
@@ -224,9 +224,9 @@ function OneManArmy:UpdateActivity()
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				--Display messages.
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", player, 0, 1000, false);
+					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", player, 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -235,8 +235,8 @@ function OneManArmy:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -249,8 +249,8 @@ function OneManArmy:UpdateActivity()
 				--Check if the player has won.
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("You survived!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
 
 					self.WinnerTeam = player;
 

--- a/Data/Base.rte/Activities/OneManArmyZeroG.lua
+++ b/Data/Base.rte/Activities/OneManArmyZeroG.lua
@@ -289,9 +289,9 @@ function OneManArmyZeroG:UpdateActivity()
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				--Display messages
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", player, 0, 1000, false);
+					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", player, 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
 				local team = self:GetTeamOfPlayer(player);
@@ -299,8 +299,8 @@ function OneManArmyZeroG:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 					--Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -311,8 +311,8 @@ function OneManArmyZeroG:UpdateActivity()
 				--Check if the player has won
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("You survived!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
 
 					self.WinnerTeam = player;
 

--- a/Data/Base.rte/Activities/Siege.lua
+++ b/Data/Base.rte/Activities/Siege.lua
@@ -280,7 +280,7 @@ function Siege:UpdateActivity()
 		end
 
 		if self:PlayerActive(player) and self:PlayerHuman(player) then
-			FrameMan:SetScreenText("Enemy assault budget: " .. math.floor(displayValue), player, 0, -1, false);
+			FrameMan:SetScreenText("Enemy assault budget: " .. math.floor(displayValue), self:ScreenOfPlayer(player), 0, -1, false);
 		end
 
 
@@ -320,8 +320,8 @@ function Siege:UpdateActivity()
 					-- self:AddObjectivePoint("Protect!", Brain.AboveHUDPos, self.PlayerTeam, GameActivity.ARROWDOWN);
 				else
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 2000, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 2000, -1, false);
 				end
 			end
 		end

--- a/Data/Base.rte/Activities/SkirmishDefense.lua
+++ b/Data/Base.rte/Activities/SkirmishDefense.lua
@@ -308,7 +308,7 @@ function SkirmishDefense:UpdateActivity()
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				if not self.startTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText("Survive the assault!", player, 333, 5000, true);
+					FrameMan:SetScreenText("Survive the assault!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 				-- The current player's team
 				local team = self:GetTeamOfPlayer(player);
@@ -328,8 +328,8 @@ function SkirmishDefense:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 				else
 					playertally = playertally + 1;
 					if not setTeam[team] then

--- a/Data/Base.rte/Activities/Survival.lua
+++ b/Data/Base.rte/Activities/Survival.lua
@@ -135,12 +135,12 @@ function Survival:UpdateActivity()
 				if self.startMessageTimer:IsPastSimMS(3000) then
 					local secondsLeft = math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000);
 					if (secondsLeft > 1) then
-						FrameMan:SetScreenText(secondsLeft .. " seconds left", player, 0, 1000, false);
+						FrameMan:SetScreenText(secondsLeft .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
 					else
-						FrameMan:SetScreenText("1 second left!", player, 0, 1000, false);
+						FrameMan:SetScreenText("1 second left!", self:ScreenOfPlayer(player), 0, 1000, false);
 					end
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", player, 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -160,8 +160,8 @@ function Survival:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been destroyed!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -174,8 +174,8 @@ function Survival:UpdateActivity()
 				--Check if the player has won.
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("You survived!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
 
 					self.WinnerTeam = Activity.TEAM_1;
 

--- a/Data/Base.rte/Activities/Test.lua
+++ b/Data/Base.rte/Activities/Test.lua
@@ -70,14 +70,14 @@ function Test:UpdateActivity()
 	if self.doorMessageTimer then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
-				FrameMan:SetScreenText("NOTE: You can press ALT + 1 to open or close all doors", player, 0, -1, false);
+				FrameMan:SetScreenText("NOTE: You can press ALT + 1 to open or close all doors", self:ScreenOfPlayer(player), 0, -1, false);
 			end
 		end
 		if self.doorMessageTimer:IsPastSimTimeLimit() then
 			self.doorMessageTimer = nil;
 			for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 				if self:PlayerActive(player) and self:PlayerHuman(player) then
-					FrameMan:ClearScreenText(player);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 				end
 			end
 		end

--- a/Data/Base.rte/Activities/WaveDefense.lua
+++ b/Data/Base.rte/Activities/WaveDefense.lua
@@ -211,7 +211,7 @@ function WaveDefense:UpdateActivity()
 			local time = math.floor(self.PrepareForNextWaveTimer:LeftTillRealTimeLimitMS() / 1000);
 			for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 				if self:PlayerActive(player) and self:PlayerHuman(player) then
-					FrameMan:SetScreenText("The next wave arrive in "..time.." seconds. Press [Space] to enter edit mode.", player, 0, 100, false);
+					FrameMan:SetScreenText("The next wave arrive in "..time.." seconds. Press [Space] to enter edit mode.", self:ScreenOfPlayer(player), 0, 100, false);
 				end
 			end
 
@@ -292,8 +292,8 @@ function WaveDefense:UpdateActivity()
 			end
 		end
 
-		-- Show the remaining funds and current wave on player 1's screen only
-		FrameMan:ClearScreenText(Activity.PLAYER_1);
+		-- Show the remaining funds and current wave on first screen only
+		FrameMan:ClearScreenText(0);
 		local str = "Wave "..self.wave.."  |  ";
 		local remainingFunds = math.floor(self:GetTeamFunds(self.CPUTeam));
 		if remainingFunds <= 0 then
@@ -301,7 +301,7 @@ function WaveDefense:UpdateActivity()
 		else
 			str = str .. "Remaining Enemy Budget: " .. remainingFunds .. " oz";
 		end
-		FrameMan:SetScreenText(str, Activity.PLAYER_1, 0, 10, false);
+		FrameMan:SetScreenText(str, 0, 0, 10, false);
 
 		-- Clear all objective markers, they get re-added each frame
 		self:ClearObjectivePoints()
@@ -312,7 +312,7 @@ function WaveDefense:UpdateActivity()
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				if not self.StartTimer:IsPastRealMS(3000) then
-					FrameMan:SetScreenText("Survive wave "..self.wave, player, 333, 5000, true);
+					FrameMan:SetScreenText("Survive wave "..self.wave, self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -332,9 +332,9 @@ function WaveDefense:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(player);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 					local str = "Your brain has been destroyed on wave "..self.wave.." at "..self.Difficulty.."% difficulty";
-					FrameMan:SetScreenText(str, player, 333, -1, false);
+					FrameMan:SetScreenText(str, self:ScreenOfPlayer(player), 333, -1, false);
 				else
 					playertally = playertally + 1;
 					if not setTeam[team] then
@@ -371,7 +371,7 @@ function WaveDefense:UpdateActivity()
 			else
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:SetScreenText("Wave "..self.wave.." defeated!", player, 250, 500, true);
+						FrameMan:SetScreenText("Wave "..self.wave.." defeated!", self:ScreenOfPlayer(player), 250, 500, true);
 					end
 				end
 			end

--- a/Data/Missions.rte/Activities/DecisionDay.lua
+++ b/Data/Missions.rte/Activities/DecisionDay.lua
@@ -1109,8 +1109,8 @@ end
 
 function DecisionDay:UpdateMessages()
 	if self.speedrunData and ActivitySpeedrunHelper.SpeedrunActive(self.speedrunData) then
-		FrameMan:ClearScreenText(Activity.PLAYER_1);
-		FrameMan:SetScreenText(ActivitySpeedrunHelper.GetSpeedrunDuration(self.speedrunData), Activity.PLAYER_1, 0, 1, ActivitySpeedrunHelper.SpeedrunCompleted(self.speedrunData));
+		FrameMan:ClearScreenText(0);
+		FrameMan:SetScreenText(ActivitySpeedrunHelper.GetSpeedrunDuration(self.speedrunData), 0, 0, 1, ActivitySpeedrunHelper.SpeedrunCompleted(self.speedrunData));
 		return;
 	end
 
@@ -1204,8 +1204,8 @@ function DecisionDay:UpdateMessages()
 		end
 
 		if messageText then
-			FrameMan:ClearScreenText(player);
-			FrameMan:SetScreenText(messageText, player, blinkTime, 0, textCentered);
+			FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+			FrameMan:SetScreenText(messageText, self:ScreenOfPlayer(player), blinkTime, 0, textCentered);
 		end
 	end
 end

--- a/Data/Missions.rte/Activities/DummyAssault.lua
+++ b/Data/Missions.rte/Activities/DummyAssault.lua
@@ -96,8 +96,8 @@ function DummyAssault:EndActivity()
 	if self.humanTeam == self.WinnerTeam then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
-				FrameMan:ClearScreenText(player);
-				FrameMan:SetScreenText("Congratulations, you've destroyed the enemy base!", player, 0, -1, false);
+				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+				FrameMan:SetScreenText("Congratulations, you've destroyed the enemy base!", self:ScreenOfPlayer(player), 0, -1, false);
 			end
 		end
 	end
@@ -139,7 +139,7 @@ function DummyAssault:UpdateActivity()
 						self:SwitchToActor(newBrain, player, team);
 						self:GetBanner(GUIBanner.RED, player):ClearText();
 					else
-						FrameMan:SetScreenText("Your brain has been lost!", player, 333, -1, false);
+						FrameMan:SetScreenText("Your brain has been lost!", self:ScreenOfPlayer(player), 333, -1, false);
 						self.brainDead[player] = true;
 						-- Now see if all brains of self player's team are dead, and if so, end the game
 						if not MovableMan:GetFirstBrainActor(team) then

--- a/Data/Missions.rte/Activities/Maginot.lua
+++ b/Data/Missions.rte/Activities/Maginot.lua
@@ -71,7 +71,7 @@ function MaginotMission:StartNewGame()
 	for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 		if self:PlayerActive(player) and self:PlayerHuman(player) and not self:GetPlayerBrain(player) then
 			self:ResetMessageTimer(player);
-			FrameMan:ClearScreenText(player);
+			FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 		end
 	end
 end
@@ -161,7 +161,7 @@ function MaginotMission:DoGameOverCheck()
 							end
 							self:GetBanner(GUIBanner.RED, player):ClearText();
 						else
-							FrameMan:SetScreenText("Your brain has been lost!", player, 333, -1, false);
+							FrameMan:SetScreenText("Your brain has been lost!", self:ScreenOfPlayer(player), 333, -1, false);
 							self.brainDead[player] = true;
 
 							local gameOver = true;
@@ -194,11 +194,11 @@ function MaginotMission:DoGameOverCheck()
 				self:GetBanner(GUIBanner.RED, player):ClearText();
 
 				if not self.GameOverTimer:IsPastSimMS(self.GameOverPeriod) then
-					FrameMan:ClearScreenText(player);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 					if self.brainDead[player] then
-						FrameMan:SetScreenText("You may have died, but your fellow brains lived to fight another day. Rest assured, you will be avenged!", player, 0, 1, false);
+						FrameMan:SetScreenText("You may have died, but your fellow brains lived to fight another day. Rest assured, you will be avenged!", self:ScreenOfPlayer(player), 0, 1, false);
 					else
-						FrameMan:SetScreenText("Good job, you lived to fight another day. We've located the enemy fortress and are planning an assault on it!", player, 0, 1, false);
+						FrameMan:SetScreenText("Good job, you lived to fight another day. We've located the enemy fortress and are planning an assault on it!", self:ScreenOfPlayer(player), 0, 1, false);
 					end
 				else
 					ActivityMan:EndActivity();
@@ -246,25 +246,25 @@ function MaginotMission:UpdateScreenText()
 	if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
-				FrameMan:ClearScreenText(player);
+				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 				if self.currentFightStage == self.fightStage.beginFight then
 					if self:GetTeamFunds(self.defenderTeam) == 0 then
-						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nYou'll have to make do with the forces you have on site. Good luck!", player, 0, 1, false);
+						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nYou'll have to make do with the forces you have on site. Good luck!", self:ScreenOfPlayer(player), 0, 1, false);
 					else
-						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nPrepare while you can, they'll be here soon!", player, 0, 1, false);
+						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nPrepare while you can, they'll be here soon!", self:ScreenOfPlayer(player), 0, 1, false);
 					end
 				elseif self.currentFightStage == self.fightStage.defendLeft then
-					FrameMan:SetScreenText("The onslaught has begun. Hold the line!", player, 1500, 1, true);
+					FrameMan:SetScreenText("The onslaught has begun. Hold the line!", self:ScreenOfPlayer(player), 1500, 1, true);
 				elseif self.currentFightStage == self.fightStage.defendRight then
-					FrameMan:SetScreenText("ALERT: A ground attack force is moving on the Eastern entrance!", player, 1500, 1, true);
+					FrameMan:SetScreenText("ALERT: A ground attack force is moving on the Eastern entrance!", self:ScreenOfPlayer(player), 1500, 1, true);
 				elseif self.currentFightStage == self.fightStage.evacuateBrain then
 					if self.PlayerCount == 1 then
-						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brain has been loaded onto a bot, get to the LZ and evacuate.", player, 0, 1, true);
+						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brain has been loaded onto a bot, get to the LZ and evacuate.", self:ScreenOfPlayer(player), 0, 1, true);
 					else
-						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brains have been loaded onto bots, get as many of them as possible to the LZ and evacuate.", player, 0, 1, true);
+						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brains have been loaded onto bots, get as many of them as possible to the LZ and evacuate.", self:ScreenOfPlayer(player), 0, 1, true);
 					end
 				elseif self.currentFightStage == self.fightStage.enterEvacuationRocket then
-					FrameMan:SetScreenText("The evacuation rocket is coming in hot, get to the LZ!", player, 1500, 1, true);
+					FrameMan:SetScreenText("The evacuation rocket is coming in hot, get to the LZ!", self:ScreenOfPlayer(player), 1500, 1, true);
 				end
 			end
 		end

--- a/Data/Missions.rte/Activities/SignalHunt.lua
+++ b/Data/Missions.rte/Activities/SignalHunt.lua
@@ -458,8 +458,8 @@ end
 
 function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 	if self.speedrunData and ActivitySpeedrunHelper.SpeedrunActive(self.speedrunData) then
-		FrameMan:ClearScreenText(Activity.PLAYER_1);
-		FrameMan:SetScreenText(ActivitySpeedrunHelper.GetSpeedrunDuration(self.speedrunData), Activity.PLAYER_1, 0, 1, ActivitySpeedrunHelper.SpeedrunCompleted(self.speedrunData));
+		FrameMan:ClearScreenText(0);
+		FrameMan:SetScreenText(ActivitySpeedrunHelper.GetSpeedrunDuration(self.speedrunData), 0, 0, 1, ActivitySpeedrunHelper.SpeedrunCompleted(self.speedrunData));
 		return;
 	end
 	if self.WinnerTeam == -1 then
@@ -469,8 +469,8 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 				if brain and self.currentFightStage > self.fightStage.beginFight and (not self.actorHoldingControlChip or self.actorHoldingControlChip.UniqueID ~= brain.UniqueID) and (not self.evacuationRocket or self.evacuationRocket.UniqueID ~= brain.UniqueID) then
 					self:AddObjectivePoint("Protect!", brain.AboveHUDPos, self.humanTeam, GameActivity.ARROWDOWN);
 				elseif not brain then
-					FrameMan:ClearScreenText(player);
-					FrameMan:SetScreenText("Your brain has been lost!", player, 333, -1, false);
+					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:SetScreenText("Your brain has been lost!", self:ScreenOfPlayer(player), 333, -1, false);
 				end
 			end
 		end
@@ -479,8 +479,8 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(player);
-						FrameMan:SetScreenText("Contractor, we at Alchiral appreciate your cooperation and confidentiality on this assignment.\nPlease enter the cave to ascertain the source of the signal.", player, 0, 1, false);
+						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+						FrameMan:SetScreenText("Contractor, we at Alchiral appreciate your cooperation and confidentiality on this assignment.\nPlease enter the cave to ascertain the source of the signal.", self:ScreenOfPlayer(player), 0, 1, false);
 					end
 				end
 			else
@@ -495,8 +495,8 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(player);
-						FrameMan:SetScreenText("Contractor, these cloning tubes are not your primary target.\nYou may destroy them if they are obstructing your progress, but your task is to find the source of the signal.\nProceed farther into the cave.", player, 0, 1, false);
+						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+						FrameMan:SetScreenText("Contractor, these cloning tubes are not your primary target.\nYou may destroy them if they are obstructing your progress, but your task is to find the source of the signal.\nProceed farther into the cave.", self:ScreenOfPlayer(player), 0, 1, false);
 					end
 				end
 			else
@@ -506,8 +506,8 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(player);
-						FrameMan:SetScreenText("Contractor, the signal is coming from that case; there is a modified Alchiral Cloning Control Chip inside it.\nDestroy the case and retrieve our property, once the chip is outside we will send a rocket to evacuate it to orbit.", player, 0, 1, false);
+						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+						FrameMan:SetScreenText("Contractor, the signal is coming from that case; there is a modified Alchiral Cloning Control Chip inside it.\nDestroy the case and retrieve our property, once the chip is outside we will send a rocket to evacuate it to orbit.", self:ScreenOfPlayer(player), 0, 1, false);
 					end
 				end
 			end
@@ -516,8 +516,8 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if self.secretIndex == nil and not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(player);
-						FrameMan:SetScreenText(self:GetTeamOfPlayer(player) == self.humanTeam and "Get To The Rocket!!!" or "Y O U R   W I S H   I S   O U R   C O M M A N D,   O   D R E A D   L O R D\nW E   S H A L L   S L A U G H T E R   E V E R Y O N E", player, 0, 1, true);
+						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+						FrameMan:SetScreenText(self:GetTeamOfPlayer(player) == self.humanTeam and "Get To The Rocket!!!" or "Y O U R   W I S H   I S   O U R   C O M M A N D,   O   D R E A D   L O R D\nW E   S H A L L   S L A U G H T E R   E V E R Y O N E", self:ScreenOfPlayer(player), 0, 1, true);
 					end
 				end
 			else
@@ -525,8 +525,8 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 					if not self.evacuationRocketSpawned and self.numberOfAmbushingCraft > 0 then
 						for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 							if self:PlayerActive(player) and self:PlayerHuman(player) then
-								FrameMan:ClearScreenText(player);
-								FrameMan:SetScreenText("ALERT: Contractor, unknown hostiles are entering the area. They must not retrieve the Cloning Control Chip!", player, 500, 1, true);
+								FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+								FrameMan:SetScreenText("ALERT: Contractor, unknown hostiles are entering the area. They must not retrieve the Cloning Control Chip!", self:ScreenOfPlayer(player), 500, 1, true);
 							end
 						end
 					end
@@ -548,19 +548,19 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 	elseif self.WinnerTeam == self.humanTeam and not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
-				FrameMan:ClearScreenText(player);
+				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 				local endText = "Contractor, thank you for your efficient work. Your agreed-upon fee has been deposited to your account.\nWe at Alchiral are pleased with your performance, and look forward to a productive relationship with you in future.";
 				if self.secretIndex == nil then
 					endText = self:GetTeamOfPlayer(player) == self.humanTeam and "You may not have the chip, but at least you made it out after that betrayal!" or "D R E A D   L O R D,   T H E Y   H A V E   E S C A P E D   A N D   W I L L\nB R I N G   R U I N   D O W N   U P O N   U S   B E F O R E   W E   A R E   P R E P A R E D";
 				end
-				FrameMan:SetScreenText(endText, player, 0, 1, true);
+				FrameMan:SetScreenText(endText, self:ScreenOfPlayer(player), 0, 1, true);
 			end
 		end
 	elseif self.WinnerTeam == self.zombieTeam and not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) and self:GetTeamOfPlayer(player) == self.zombieTeam then
-				FrameMan:ClearScreenText(player);
-				FrameMan:SetScreenText("A    G R A N D    V I C T O R Y ,   Y O U R    H O R D E    S H A L L    G R O W    A N D    C O N Q U E R    T H I S    P L A N E T", player, 0, 1, true);
+				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+				FrameMan:SetScreenText("A    G R A N D    V I C T O R Y ,   Y O U R    H O R D E    S H A L L    G R O W    A N D    C O N Q U E R    T H I S    P L A N E T", self:ScreenOfPlayer(player), 0, 1, true);
 			end
 		end
 	end


### PR DESCRIPTION
`FrameMan.ClearScreenText()` and `FrameMan.SetScreenText()` take a screen index, but are regularly passed a player index instead. If the players aren't all sequential (e.g. player 2 and player 4 are playing), then some or all of these functions may operate on the wrong screen, or no screen at all. Fortunately, some activities correctly call `Activity.ScreenOfPlayer()`, so they didn't *all* need fixing.

Additionally, some activities iterated over players incorrectly, going from `0` to `PlayerCount - 1` instead of iterating from `PLAYER_1` to `MAXPLAYERCOUNT - 1` and filtering for active human players. This made Exploration (Doainar) impossible to progress if you decided to use a different player than player 1.

Lastly, some activities intentionally displayed a message only for `PLAYER_1`. These were changed to instead use an explicit `0` to indicate they should always use the first screen, except for Massacre, which only displayed the remaining kills needed for `PLAYER_1`, but was doing so inside a for loop iterating over all active players. Since it wasn't entirely clear that this behavior was intentional, and since it was already being called for each player, I made it use `self:ScreenOfPlayer(player)` instead.