### PR TITLE
Minor fix and balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Massacre now displays the remaining kill count to each player's screen instead of just the first one.
 
+- Slightly nerfed the Imperatus combat robot jetpack.
+
 </details>
 
 <details><summary><b>Fixed</b></summary>
@@ -25,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed a missing Lua write binding for `AEJetpack`'s `JetTimeLeft` property.
 
 - Fixed an issue where glows wouldn't render if the EffectStopTime was lower than the simulation deltatime.
+
+- Fixed an issue where a mission-only item was being bought by the AI.
 
 </details>
 

--- a/Data/Browncoats.rte/Devices.ini
+++ b/Data/Browncoats.rte/Devices.ini
@@ -43,4 +43,4 @@ IncludeFile = Browncoats.rte/Devices/Tools/Blowtorch/Blowtorch.ini
 
 // Mission-related
 
-IncludeFile = Browncoats.rte/Devices/Mission/RefineryKeycard/RefineryKeycard.ini
+//IncludeFile = Browncoats.rte/Devices/Mission/RefineryKeycard/RefineryKeycard.ini

--- a/Data/Imperatus.rte/Actors/Shared.ini
+++ b/Data/Imperatus.rte/Actors/Shared.ini
@@ -23,8 +23,8 @@ AddEffect = AEJetpack
 		MinVelocity = 16
 		LifeVariation = 0.20
 	NegativeThrottleMultiplier = 0.8
-	PositiveThrottleMultiplier = 1.2
-	ParticlesPerMinute = 9600
+	PositiveThrottleMultiplier = 1.05
+	ParticlesPerMinute = 8400
 	BurstSize = 9
 	BurstSpacing = 200
 	


### PR DESCRIPTION
Disable item that was showing up in random scripts that merely scanned for Buyable

Nerf imperatus jetpack to make it not the strongest in the game