### PR TITLE
Survival and BunkerBreach explicitly set door ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed an issue where glows wouldn't render if the EffectStopTime was lower than the simulation deltatime.
 
+- Fixed an issue where sometimes doors were owned by the wrong team in Bunker Breach and Survival activities.
+
 </details>
 
 ## [Release v6.1.0] - 2024/02/15

--- a/Data/Base.rte/Activities/BunkerBreach.lua
+++ b/Data/Base.rte/Activities/BunkerBreach.lua
@@ -157,6 +157,9 @@ function BunkerBreach:SetupDefenderActors()
 			elseif actor.Team ~= self.defenderTeam then
 				MovableMan:ChangeActorTeam(actor, self.defenderTeam);
 			end
+		elseif IsADoor(actor) then
+			-- Give every door to the defender team
+			actor.Team = self.defenderTeam;
 		end
 	end
 	

--- a/Data/Base.rte/Activities/Survival.lua
+++ b/Data/Base.rte/Activities/Survival.lua
@@ -67,6 +67,13 @@ function Survival:StartNewGame()
 		self.randomSpawnTime = 4000;
 	end
 	self.enemySpawnTimeLimit = (self.baseSpawnTime + math.random(self.randomSpawnTime)) * rte.SpawnIntervalScale;
+	
+	for actor in MovableMan.AddedActors do
+		if IsADoor(actor) then
+			-- Give every door to the player team
+			actor.Team = self:GetTeamOfPlayer(Activity.PLAYER_1);
+		end
+	end
 
 	self:SetupHumanPlayerBrains();
 end


### PR DESCRIPTION
Fixes doors being owned by the wrong team because they'd just follow whatever the Scene had them set as