### PR TITLE
Fixed IgnoreTerrain not having any effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed an issue where a mission-specific keycard item was being bought by the AI.
 
+- Fixed `MovableObject` INI property `IgnoreTerrain` not having any appreciable effect.
+
 </details>
 
 ## [Release v6.1.0] - 2024/02/15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed an issue where a mission-specific keycard item was being bought by the AI.
 
-- Fixed `MovableObject` INI property `IgnoreTerrain` not having any appreciable effect.
+- Fixed `MovableObject` INI and Lua property `IgnoreTerrain` not having any appreciable effect.
 
 </details>
 

--- a/Source/System/Atom.cpp
+++ b/Source/System/Atom.cpp
@@ -552,7 +552,7 @@ bool Atom::StepForward(int numSteps) {
 			g_SceneMan.WrapPosition(m_IntPos[X], m_IntPos[Y]);
 
 			// Detect terrain hits, if not disabled.
-			if (g_MaterialAir != (m_TerrainMatHit = g_SceneMan.GetTerrMatter(m_IntPos[X], m_IntPos[Y]))) {
+			if (g_MaterialAir != (m_TerrainMatHit = g_SceneMan.GetTerrMatter(m_IntPos[X], m_IntPos[Y])) && !m_OwnerMO->m_IgnoreTerrain) {
 				// Check if we're temporarily disabled from hitting terrain
 				if (!m_TerrainHitsDisabled) {
 					m_OwnerMO->SetHitWhatTerrMaterial(m_TerrainMatHit);
@@ -766,7 +766,7 @@ int Atom::Travel(float travelTime, bool autoTravel, bool scenePreLocked) {
 		// Bresenham's line drawing algorithm execution
 		for (domSteps = 0; domSteps < delta[dom] && !(hit[X] || hit[Y]); ++domSteps) {
 			// Check for the special case if the Atom is starting out embedded in terrain. This can happen if something large gets copied to the terrain and embeds some Atoms.
-			if (domSteps == 0 && g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]) != g_MaterialAir) {
+			if (domSteps == 0 && !m_OwnerMO->m_IgnoreTerrain && g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]) != g_MaterialAir) {
 				++hitCount;
 				hit[X] = hit[Y] = true;
 				if (g_SceneMan.TryPenetrate(intPos[X], intPos[Y], velocity * mass * sharpness, velocity, retardation, 0.5F, m_NumPenetrations, removeOrphansRadius, removeOrphansMaxArea, removeOrphansRate)) {

--- a/Source/System/Atom.cpp
+++ b/Source/System/Atom.cpp
@@ -552,7 +552,7 @@ bool Atom::StepForward(int numSteps) {
 			g_SceneMan.WrapPosition(m_IntPos[X], m_IntPos[Y]);
 
 			// Detect terrain hits, if not disabled.
-			if (g_MaterialAir != (m_TerrainMatHit = g_SceneMan.GetTerrMatter(m_IntPos[X], m_IntPos[Y])) && !m_OwnerMO->m_IgnoreTerrain) {
+			if (!m_OwnerMO->m_IgnoreTerrain && g_MaterialAir != (m_TerrainMatHit = g_SceneMan.GetTerrMatter(m_IntPos[X], m_IntPos[Y]))) {
 				// Check if we're temporarily disabled from hitting terrain
 				if (!m_TerrainHitsDisabled) {
 					m_OwnerMO->SetHitWhatTerrMaterial(m_TerrainMatHit);
@@ -766,7 +766,7 @@ int Atom::Travel(float travelTime, bool autoTravel, bool scenePreLocked) {
 		// Bresenham's line drawing algorithm execution
 		for (domSteps = 0; domSteps < delta[dom] && !(hit[X] || hit[Y]); ++domSteps) {
 			// Check for the special case if the Atom is starting out embedded in terrain. This can happen if something large gets copied to the terrain and embeds some Atoms.
-			if (domSteps == 0 && !m_OwnerMO->m_IgnoreTerrain && g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]) != g_MaterialAir) {
+			if (!m_OwnerMO->m_IgnoreTerrain && domSteps == 0 && g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]) != g_MaterialAir) {
 				++hitCount;
 				hit[X] = hit[Y] = true;
 				if (g_SceneMan.TryPenetrate(intPos[X], intPos[Y], velocity * mass * sharpness, velocity, retardation, 0.5F, m_NumPenetrations, removeOrphansRadius, removeOrphansMaxArea, removeOrphansRate)) {
@@ -902,7 +902,7 @@ int Atom::Travel(float travelTime, bool autoTravel, bool scenePreLocked) {
 			// Atom-Terrain collision detection and response.
 
 			// If there was no MO collision detected, then check for terrain hits.
-			else if ((hitMaterialID = g_SceneMan.GetTerrMatter(intPos[X], intPos[Y])) && !m_OwnerMO->m_IgnoreTerrain) {
+			else if (!m_OwnerMO->m_IgnoreTerrain && (hitMaterialID = g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]))) {
 				if (hitMaterialID != g_MaterialAir) {
 					m_OwnerMO->SetHitWhatTerrMaterial(hitMaterialID);
 				}


### PR DESCRIPTION
Previously, `IgnoreTerrain` on `MovableObjects` would have little to no effect on terrain collisions; now it correctly toggles all terrain collisions.