### PR TITLE
Activities: Fix more player 1 assumptions, make broken code to avoid deploying on a player work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `LERP` Lua binding has been deprecated, and renamed to `Lerp`.
 
+- Six activities (Harvester, Keepie-Uppie, Massacre, One-Man Army, One-Man Army (Diggers Only), and Survival) now avoid AI deployments on top of the player.
+
 </details>
 
 <details><summary><b>Fixed</b></summary>
@@ -53,6 +55,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue where a mission-specific keycard item was being bought by the AI.
 
 - Fixed `MovableObject` INI and Lua property `IgnoreTerrain` not having any appreciable effect.
+
+- Fixed Signal Hunt speedrun mode not working properly if you used a player other than 1.
+
+- Fixed Decision Day camera potentially getting stuck at the start if player 1 wasn't present.
 
 </details>
 

--- a/Data/Base.rte/Activities/Harvester.lua
+++ b/Data/Base.rte/Activities/Harvester.lua
@@ -294,11 +294,11 @@ function Harvester:UpdateActivity()
 
 			if ship then
 				-- Set the spawn point of the ship from orbit
-				if self.playertally == 1 then
-					for i = 1, #self.playerlist do
-						if self.playerlist[i] == true then
+				if self.HumanCount == 1 then
+					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
+						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
-							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
+							local checkPos = self:GetPlayerBrain(player).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then
 								checkPos = checkPos - SceneMan.SceneWidth;
 							elseif checkPos < 0 then

--- a/Data/Base.rte/Activities/Harvester.lua
+++ b/Data/Base.rte/Activities/Harvester.lua
@@ -209,7 +209,7 @@ function Harvester:UpdateActivity()
 		end
 
 		if self.addFogOfWar then
-			SceneMan:MakeAllUnseen(Vector(20, 20), self:GetTeamOfPlayer(Activity.PLAYER_1));
+			SceneMan:MakeAllUnseen(Vector(20, 20), Activity.TEAM_1);
 			self.addFogOfWar = false;
 		end
 

--- a/Data/Base.rte/Activities/KeepieUppie.lua
+++ b/Data/Base.rte/Activities/KeepieUppie.lua
@@ -226,11 +226,11 @@ function KeepieUppie:UpdateActivity()
 				end
 
 				-- Set the spawn point of the ship from orbit
-				if self.playertally == 1 then
-					for i = 1, #self.playerlist do
-						if self.playerlist[i] == true then
+				if self.HumanCount == 1 then
+					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
+						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
-							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
+							local checkPos = self:GetPlayerBrain(player).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then
 								checkPos = checkPos - SceneMan.SceneWidth;
 							elseif checkPos < 0 then

--- a/Data/Base.rte/Activities/Massacre.lua
+++ b/Data/Base.rte/Activities/Massacre.lua
@@ -297,9 +297,9 @@ function Massacre:UpdateActivity()
 
 			if ship then
 				-- Set the spawn point of the ship from orbit
-				if self.playertally == 1 then
-					for i = 1, #self.playerlist do
-						if self.playerlist[i] == true then
+				if self.HumanCount == 1 then
+					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
+						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
 							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then

--- a/Data/Base.rte/Activities/OneManArmy.lua
+++ b/Data/Base.rte/Activities/OneManArmy.lua
@@ -378,9 +378,9 @@ function OneManArmy:UpdateActivity()
 
 			if ship then
 				--Set the spawn point of the ship from orbit
-				if self.playertally == 1 then
-					for i = 1, #self.playerlist do
-						if self.playerlist[i] == true then
+				if self.HumanCount == 1 then
+					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
+						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth * 0.3;
 							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth * 0.5) + ((sceneChunk * 0.5) - (math.random() * sceneChunk));
 							if checkPos > SceneMan.SceneWidth then

--- a/Data/Base.rte/Activities/OneManArmyDiggers.lua
+++ b/Data/Base.rte/Activities/OneManArmyDiggers.lua
@@ -321,9 +321,9 @@ function OneManArmy:UpdateActivity()
 
 			if ship then
 				-- Set the spawn point of the ship from orbit
-				if self.playertally == 1 then
-					for i = 1, #self.playerlist do
-						if self.playerlist[i] == true then
+				if self.HumanCount == 1 then
+					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
+						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
 							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then

--- a/Data/Base.rte/Activities/Survival.lua
+++ b/Data/Base.rte/Activities/Survival.lua
@@ -275,9 +275,9 @@ function Survival:UpdateActivity()
 
 			if ship then
 				-- Set the spawn point of the ship from orbit
-				if self.playertally == 1 then
-					for i = 1, #self.playerlist do
-						if self.playerlist[i] == true then
+				if self.HumanCount == 1 then
+					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
+						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
 							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then

--- a/Data/Missions.rte/Activities/DecisionDay.lua
+++ b/Data/Missions.rte/Activities/DecisionDay.lua
@@ -1006,10 +1006,7 @@ function DecisionDay:UpdateCamera()
 	local scrollTargetAndSpeed;
 	if self.currentStage <= self.stages.showInitialText then
 		if self.currentStage == self.stages.showInitialText and self.messageTimer.SimTimeLimitProgress > 0.75 then
-			local brain = self:GetPlayerBrain(0);
-			if brain then
-				scrollTargetAndSpeed = {brain.Pos, fastScroll};
-			end
+			scrollTargetAndSpeed = {nil, fastScroll};
 		else
 			local dropShipToFollow = #self.initialDropShipsAndVelocities > 0 and self.initialDropShipsAndVelocities[1].dropShip or nil;
 			if dropShipToFollow then
@@ -1101,7 +1098,14 @@ function DecisionDay:UpdateCamera()
 
 	if scrollTargetAndSpeed then
 		for _, player in pairs(self.humanPlayers) do
-			CameraMan:SetScrollTarget(scrollTargetAndSpeed[1], scrollTargetAndSpeed[2], player);
+			if not scrollTargetAndSpeed[1] then
+				brain = self:GetPlayerBrain(player)
+				if brain then
+					CameraMan:SetScrollTarget(brain.pos, scrollTargetAndSpeed[2], player)
+				end
+			else
+				CameraMan:SetScrollTarget(scrollTargetAndSpeed[1], scrollTargetAndSpeed[2], player);
+			end
 		end
 	end
 	self.cameraIsPanning = scrollTargetAndSpeed ~= nil;

--- a/Resources/Credits.h
+++ b/Resources/Credits.h
@@ -27,6 +27,7 @@ R I K U   " 4 Z K "   K
 S T E W I E
 T H O M A S   " C A U S E L E S S "   M A R C H
 T O P K E K
+W I L L I A M   " M A G E K I N G 1 7 "   H O W A R D
 Z A L O
 
 Art and Content Production


### PR DESCRIPTION
Signal Hunt was only checking to see if speedrun mode should be disabled if Player 1 had a brainbot, so if you used a different player, you could activate speedrun mode after deploying and spending all your gold, somewhat undercutting the point of speedrun mode. The check now scans over every player to look for brainbots, and additionally, `DoSpeedrunMode()` also iterates over all players looking for the rocket instead of assuming Player 1 (actually a hardcoded index 0) is active.

On an unrelated note, `DoSecret()` now calls `SwitchToActor()` on the brainbot after changing its team so that it's not left under AI control until you swap back to it. It also skips setting the AI mode and target for player-controlled actors, so your brainbot won't get an automatic goto order. However, if using a player other than player 1, the HUD breaks for some reason; I have been unable to track down the reason why, and it doesn't appear to be due to an assumption about which player executed the code.

Decision Day now scrolls each player's camera to their own brainbot instead of the first player's brainbot, which (as per usual) broke if player 1 wasn't present.

Harvester was applying fog of war to `self:GetTeamOfPlayer(Activity.PLAYER_1)` without bothering to check if Player 1 was even active; since the human team is always Team 1, and the team of an inactive player is Team 1 anyway, I just changed it to that.

Six activities had a block of code using nonexistant variables to check if there was only 1 player, and if so, make the AI's deployment unable to pick a spot directly above the player's head. I changed it to instead use existing variables, so the code should now function properly.