### PR TITLE
Gate populating metagame tech dropdown and team icons behind flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed Decision Day camera potentially getting stuck at the start if player 1 wasn't present.
 
+- Fixed Conquest tech selection dropdown getting repeatedly repopulated with duplicated entries, which could cause a crash.
+
 </details>
 
 <details><summary><b>Removed</b></summary>

--- a/Source/Menus/MetagameGUI.h
+++ b/Source/Menus/MetagameGUI.h
@@ -772,6 +772,8 @@ namespace RTE {
 		// The scene currently being played, NOT OWNED
 		Scene* m_pPlayingScene;
 
+		bool m_TechAndFlagListFetched; //!< Whether the tech list was fetched and each team's ComboBox was populated with it, even if no valid tech modules were added. The team flags are also populated at the same time.
+
 		// NEW GAME DIALOG
 		// Game size label and slider
 		GUILabel* m_pSizeLabel;

--- a/Source/Menus/ScenarioActivityConfigGUI.cpp
+++ b/Source/Menus/ScenarioActivityConfigGUI.cpp
@@ -73,17 +73,19 @@ void ScenarioActivityConfigGUI::PopulateTechComboBoxes() {
 	for (int team = Activity::Teams::TeamOne; team < Activity::Teams::MaxTeamCount; ++team) {
 		m_TeamTechComboBoxes[team]->GetListPanel()->AddItem("-All-", "", nullptr, nullptr, -2);
 		m_TeamTechComboBoxes[team]->GetListPanel()->AddItem("-Random-", "", nullptr, nullptr, -1);
+		m_TeamTechComboBoxes[team]->SetSelectedIndex(0);
 	}
 	for (int moduleID = 0; moduleID < g_PresetMan.GetTotalModuleCount(); ++moduleID) {
 		if (const DataModule* dataModule = g_PresetMan.GetDataModule(moduleID)) {
 			if (dataModule->IsFaction()) {
 				for (int team = Activity::Teams::TeamOne; team < Activity::Teams::MaxTeamCount; ++team) {
 					m_TeamTechComboBoxes[team]->GetListPanel()->AddItem(dataModule->GetFriendlyName(), "", nullptr, nullptr, moduleID);
-					m_TeamTechComboBoxes[team]->GetListPanel()->ScrollToTop();
-					m_TeamTechComboBoxes[team]->SetSelectedIndex(0);
 				}
 			}
 		}
+	}
+	for (int team = Activity::Teams::TeamOne; team < Activity::Teams::MaxTeamCount; ++team) {
+		m_TeamTechComboBoxes[team]->GetListPanel()->ScrollToTop();
 	}
 	m_TechListFetched = true;
 }


### PR DESCRIPTION
Every time `MetagameGUI::SetEnabled()` was called, each player's tech selection dropdown would get all its entries added to it again. Since the selection code relied on "-Random-" being the first element of the dropdown, if any other "-Random-" entry were selected (even by the random selecvtion code itself!), the player's `m_NativeTechModule` would get set to `-1`. The same commit that moved the code to `MetagameGUI::SetEnabled()` also did something similar to `ScenarioActivityConfigGUI`, but with one key difference: a boolean flag to determine whether or not that loading had occurred. By adding the same to `MetagameUI`, it can be ensured that the tech list only gets populated once.

Additionally, the code was calling `m_apPlayerTechSelect[player]->GetListPanel()->ScrollToTop()` after *every single tech* was added to the list; it makes much more sense just to do it once after finishing. Since `ScenarioActivityConfigGUI` did something similar, I changed it as well. The performance impact is probably negligible, but it's still less redundant function calls.

Lastly, possibly due to copying code from `ScenarioActivityConfigGUI`, the `MetagameGUI` code was iterating through teams instead of players. This had functionally the same effect, but it's more consistent to use `Players::PlayerOne` and `Players::MaxPlayerCount` than `Activity::Teams::TeamOne` and `Activity::Teams::MaxTeamCount` given that, unlike activities, each row is guaranteed to only be one player.