### PR TITLE
Add missing HDFirearm EjectionOffset and EjectionPos bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `Lerp` can now be used on Vectors and Matrices/Rotations, not just numbers.
 
-- Added missing `HDFirearm` lua bindings, `EjectionOffset` (R/W) and `EjectionPos` (R). Work similarly to their Muzzle variants.
+- Added `HDFirearm` lua bindings `EjectionOffset` (R/W) and `EjectionPos` (R). Work similarly to their Muzzle variants.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `Lerp` can now be used on Vectors and Matrices/Rotations, not just numbers.
 
+- Added missing `HDFirearm` lua bindings, `EjectionOffset` (R/W) and `EjectionPos` (R). Work similarly to their Muzzle variants.
+
 </details>
 
 <details><summary><b>Changed</b></summary>

--- a/Source/Entities/HDFirearm.cpp
+++ b/Source/Entities/HDFirearm.cpp
@@ -531,6 +531,10 @@ Vector HDFirearm::GetMuzzlePos() const {
 	return m_Pos + RotateOffset(m_MuzzleOff);
 }
 
+Vector HDFirearm::GetEjectionPos() const {
+	return m_Pos + RotateOffset(m_EjectOff);
+}
+
 void HDFirearm::RestDetection() {
 	HeldDevice::RestDetection();
 

--- a/Source/Entities/HDFirearm.h
+++ b/Source/Entities/HDFirearm.h
@@ -273,8 +273,23 @@ namespace RTE {
 
 		/// Sets the unrotated relative offset from the position to the muzzle or
 		/// other equivalent point of this.
-		/// @param newOffset Bew ofsset value.
+		/// @param newOffset New offset value.
 		void SetMuzzleOffset(Vector newOffset) override { m_MuzzleOff = newOffset; }
+
+		/// Gets the absolute position of the muzzle or other equivalent point of
+		/// this.
+		/// @return A vector describing the absolute world coordinates for the Shell
+		/// ejection point of this
+		Vector GetEjectionPos() const;
+
+		/// Gets the unrotated relative offset from the position to the Shell ejection point.
+		/// @return A unrotated vector describing the relative for the Shell ejection point of
+		/// this from this' position.
+		Vector GetEjectionOffset() const { return m_EjectOff; }
+
+		/// Sets the unrotated relative offset from the position to the Shell ejection point.
+		/// @param newOffset New offset value.
+		void SetEjectionOffset(Vector newOffset) { m_EjectOff = newOffset; }
 
 		/// Gets this HDFirearm's pre fire sound. Ownership is NOT transferred!
 		/// @return The SoundContainer for this HDFirearm's pre fire sound.

--- a/Source/Entities/HDFirearm.h
+++ b/Source/Entities/HDFirearm.h
@@ -276,8 +276,7 @@ namespace RTE {
 		/// @param newOffset New offset value.
 		void SetMuzzleOffset(Vector newOffset) override { m_MuzzleOff = newOffset; }
 
-		/// Gets the absolute position of the muzzle or other equivalent point of
-		/// this.
+		/// Gets the absolute position of the Shell ejection point.
 		/// @return A vector describing the absolute world coordinates for the Shell
 		/// ejection point of this
 		Vector GetEjectionPos() const;

--- a/Source/Lua/LuaBindingsEntities.cpp
+++ b/Source/Lua/LuaBindingsEntities.cpp
@@ -607,6 +607,8 @@ LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, HDFirearm) {
 	return ConcreteTypeLuaClassDefinition(HDFirearm, HeldDevice)
 
 	    .property("ReloadEndOffset", &HDFirearm::GetReloadEndOffset, &HDFirearm::SetReloadEndOffset)
+		.property("EjectionPos", &HDFirearm::GetEjectionPos)
+		.property("EjectionOffset", &HDFirearm::GetEjectionOffset, &HDFirearm::SetEjectionOffset)
 	    .property("RateOfFire", &HDFirearm::GetRateOfFire, &HDFirearm::SetRateOfFire)
 	    .property("MSPerRound", &HDFirearm::GetMSPerRound)
 	    .property("FullAuto", &HDFirearm::IsFullAuto, &HDFirearm::SetFullAuto)

--- a/Source/Lua/LuaBindingsEntities.cpp
+++ b/Source/Lua/LuaBindingsEntities.cpp
@@ -607,8 +607,8 @@ LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, HDFirearm) {
 	return ConcreteTypeLuaClassDefinition(HDFirearm, HeldDevice)
 
 	    .property("ReloadEndOffset", &HDFirearm::GetReloadEndOffset, &HDFirearm::SetReloadEndOffset)
-		.property("EjectionPos", &HDFirearm::GetEjectionPos)
-		.property("EjectionOffset", &HDFirearm::GetEjectionOffset, &HDFirearm::SetEjectionOffset)
+	    .property("EjectionPos", &HDFirearm::GetEjectionPos)
+	    .property("EjectionOffset", &HDFirearm::GetEjectionOffset, &HDFirearm::SetEjectionOffset)
 	    .property("RateOfFire", &HDFirearm::GetRateOfFire, &HDFirearm::SetRateOfFire)
 	    .property("MSPerRound", &HDFirearm::GetMSPerRound)
 	    .property("FullAuto", &HDFirearm::IsFullAuto, &HDFirearm::SetFullAuto)


### PR DESCRIPTION
does what it says on the tin

NOTE: the equivalent Muzzle variants of these bindings are defined blankly in HeldDevice and then overriden in HDFirearm. this felt completely vestigial and pointless, so i made THESE bindings just directly in HDFirearm.