### PR TITLE
Fixed issue regarding Supportable and SupportOffsetWhileReloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed Constructor auto-cancelling build mode if you actively selected the "Order Construction" pie menu option.
 
+- Fixed issue where the off hand wouldn't default to the `IdleOffset` of it's arm when the current held device had `Supportable = 0`.
+
+- Fixed edge case where having a device with `UseSupportOffsetWhileReloading = 1` and `Supportable = 0/1` depending on if it was reloading or not would result in the gun not being held by the support hand when reloading.
+
 </details>
 
 ## [Release v6.2.0] - 2024/02/19

--- a/Source/Entities/AHuman.cpp
+++ b/Source/Entities/AHuman.cpp
@@ -2243,7 +2243,7 @@ void AHuman::PreControllerUpdate() {
 				} else if (heldDevice) {
 					if (HeldDevice* bgDevice = GetEquippedBGItem(); bgDevice && !heldDevice->IsOneHanded()) {
 						UnequipBGArm();
-					} else if (!bgDevice && !heldDevice->IsReloading() && heldDevice->IsSupportable()) {
+					} else if (!bgDevice && (!heldDevice->IsReloading() || (heldDevice->IsReloading() && heldDevice->GetUseSupportOffsetWhileReloading())) && heldDevice->IsSupportable()) {
 						m_pBGArm->SetHeldDeviceThisArmIsTryingToSupport(heldDevice);
 
 						if (!m_pBGArm->HasAnyHandTargets() && m_pBGArm->GetHandHasReachedCurrentTarget()) {

--- a/Source/Entities/Arm.cpp
+++ b/Source/Entities/Arm.cpp
@@ -181,7 +181,7 @@ void Arm::Update() {
 		m_AngularVel = 0.0F;
 	}
 
-	if (m_HeldDeviceThisArmIsTryingToSupport && (!m_HeldDeviceThisArmIsTryingToSupport->IsSupportable() || m_HeldDeviceThisArmIsTryingToSupport->GetSupportOffset().MagnitudeIsGreaterThan(m_MaxLength * 2.0F))) {
+	if (m_HeldDeviceThisArmIsTryingToSupport && (!m_HeldDeviceThisArmIsTryingToSupport->IsSupportable() || !m_HeldDeviceThisArmIsTryingToSupport->IsBeingHeld() || m_HeldDeviceThisArmIsTryingToSupport->GetSupportOffset().MagnitudeIsGreaterThan(m_MaxLength * 2.0F))) {
 		m_HeldDeviceThisArmIsTryingToSupport = nullptr;
 	}
 


### PR DESCRIPTION
If a gun had SupportOffsetWhileReloading == true and you modified it's Supportable value to be only true while reloading (and false when not), the hand wouldn't support the gun on the reload. 

The one handed penalty is still applied to the reload, since the gun reloads quicker than the hand reaches the gun. 
Nothing a few lines of code in lua to restrict the reload can't fix for modders that care about it