### PR TITLE
Fix regression added in #99 that prevented enemies from spawning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed Constructor auto-cancelling build mode if you actively selected the "Order Construction" pie menu option.
 
+- Fixed regression introduced in v6.2.0 preventing Massacre, One-Man Army, One-Man Army (Diggers Only), and Survival from spawning enemies at all.
+
 </details>
 
 ## [Release v6.2.0] - 2024/02/19

--- a/Data/Base.rte/Activities/Massacre.lua
+++ b/Data/Base.rte/Activities/Massacre.lua
@@ -301,7 +301,7 @@ function Massacre:UpdateActivity()
 					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
-							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
+							local checkPos = self:GetPlayerBrain(player).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then
 								checkPos = checkPos - SceneMan.SceneWidth;
 							elseif checkPos < 0 then

--- a/Data/Base.rte/Activities/OneManArmy.lua
+++ b/Data/Base.rte/Activities/OneManArmy.lua
@@ -382,7 +382,7 @@ function OneManArmy:UpdateActivity()
 					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth * 0.3;
-							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth * 0.5) + ((sceneChunk * 0.5) - (math.random() * sceneChunk));
+							local checkPos = self:GetPlayerBrain(player).Pos.X + (SceneMan.SceneWidth * 0.5) + ((sceneChunk * 0.5) - (math.random() * sceneChunk));
 							if checkPos > SceneMan.SceneWidth then
 								checkPos = checkPos - SceneMan.SceneWidth;
 							elseif checkPos < 0 then

--- a/Data/Base.rte/Activities/OneManArmyDiggers.lua
+++ b/Data/Base.rte/Activities/OneManArmyDiggers.lua
@@ -325,7 +325,7 @@ function OneManArmy:UpdateActivity()
 					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
-							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
+							local checkPos = self:GetPlayerBrain(player).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then
 								checkPos = checkPos - SceneMan.SceneWidth;
 							elseif checkPos < 0 then

--- a/Data/Base.rte/Activities/Survival.lua
+++ b/Data/Base.rte/Activities/Survival.lua
@@ -279,7 +279,7 @@ function Survival:UpdateActivity()
 					for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 						if self:PlayerActive(player) and self:PlayerHuman(player) then
 							local sceneChunk = SceneMan.SceneWidth / 3;
-							local checkPos = self:GetPlayerBrain(i - 1).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
+							local checkPos = self:GetPlayerBrain(player).Pos.X + (SceneMan.SceneWidth/2) + ( (sceneChunk/2) - (math.random()*sceneChunk) );
 							if checkPos > SceneMan.SceneWidth then
 								checkPos = checkPos - SceneMan.SceneWidth;
 							elseif checkPos < 0 then


### PR DESCRIPTION
Apparently I got distracted partway through and forgot what I was doing, because I only got rid of the last reference to the now-removed loop variable `i` in Harvester and KeepieUppie, leaving Massacre, OneManArmy, OneManArmyDiggers, and Survival broken. Whoops!