### PR TITLE
Activities: BrainVsBrain uses Infantry Brain, OMA uses team on win.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+<details><summary><b>Changed</b></summary>
+
+- Brain vs Brain now uses the Infantry Brain preset if available, and picks a random brain if not.
+
+</details>
+
 <details><summary><b>Fixed</b></summary>
 
 - Fixed regression introduced in 6.1 causing Conquest activities to immediately fail if a defending brain was present (and probably breaking other activities as well).
 
 - Fixed the Conquest start game menu not letting you immediately start a game until you tweak some settings.
+
+- Fixed One Man Army (and Diggers Only) assigning a player to the winning team instead of a team.
 
 </details>
 

--- a/Data/Base.rte/Activities/BrainVsBrain.lua
+++ b/Data/Base.rte/Activities/BrainVsBrain.lua
@@ -125,13 +125,25 @@ function BrainvsBrain:StartNewGame()
 					local foundBrain = MovableMan:GetUnassignedBrain(self:GetTeamOfPlayer(player));
 					-- Spawn a brain if we can't find an unassigned brain in the scene to give each player
 					if not foundBrain then
-						local Brain = RandomAHuman("Brains", self:GetTeamTech(self:GetTeamOfPlayer(player)));
-						if Brain then
-							local Weapon = RandomHDFirearm("Weapons - Primary", self:GetTeamTech(self:GetTeamOfPlayer(player)));
-							if Weapon then
-								Brain:AddInventoryItem(Weapon);
+						local techID = PresetMan:GetModuleID(self:GetTeamTech(self:GetTeamOfPlayer(player)));
+						local Brain;
+						if techID ~= -1 then
+							Brain = PresetMan:GetLoadout("Infantry Brain", techID, false);
+							if Brain then
+								Brain:RemoveInventoryItem("Constructor");
 							end
+						end
+						if not Brain then
+							Brain = RandomAHuman("Brains", techID);
+							if Brain then
+								local Weapon = RandomHDFirearm("Weapons - Primary", self:GetTeamTech(self:GetTeamOfPlayer(player)));
+								if Weapon then
+									Brain:AddInventoryItem(Weapon);
+								end
+							end
+						end
 
+						if Brain then
 							Brain.AIMode = Actor.AIMODE_SENTRY;
 							Brain.Team = self:GetTeamOfPlayer(player);
 
@@ -192,13 +204,24 @@ function BrainvsBrain:StartNewGame()
 		self:SetTeamFunds(self:GetStartingGold()*(self.Difficulty/100+0.5), self.CPUTeam);
 		self.bombChance = math.random(self.Difficulty*0.7, self.Difficulty) / 120;
 
-		self.CPUBrain = CreateAHuman("Brain Robot", "Base.rte");
-		if self.CPUBrain then
-			local Weapon = CreateHDFirearm("SMG", "Base.rte");
-			if Weapon then
-				self.CPUBrain:AddInventoryItem(Weapon);
+		local techID = PresetMan:GetModuleID(self:GetTeamTech(self.CPUTeam));
+		if techID ~= -1 then
+			self.CPUBrain = PresetMan:GetLoadout("Infantry Brain", techID, false);
+			if self.CPUBrain then
+				self.CPUBrain:RemoveInventoryItem("Constructor");
 			end
+		end
+		if not self.CPUBrain then
+			self.CPUBrain = RandomAHuman("Brains", techID);
+			if self.CPUBrain then
+				local Weapon = CreateHDFirearm("SMG", "Base.rte");
+				if Weapon then
+					self.CPUBrain:AddInventoryItem(Weapon);
+				end
+			end
+		end
 
+		if self.CPUBrain then
 			self.CPUBrain.AIMode = Actor.AIMODE_SENTRY;
 			self.CPUBrain.Team = self.CPUTeam;
 

--- a/Data/Base.rte/Activities/OneManArmy.lua
+++ b/Data/Base.rte/Activities/OneManArmy.lua
@@ -255,7 +255,7 @@ end
 
 function OneManArmy:UpdateActivity()
 	if self.ActivityState ~= Activity.OVER then
-		ActivityMan:GetActivity():SetTeamFunds(0, 0);
+		ActivityMan:GetActivity():SetTeamFunds(0, Activity.TEAM_1);
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				--Display messages
@@ -285,7 +285,7 @@ function OneManArmy:UpdateActivity()
 					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
 
-					self.WinnerTeam = player;
+					self.WinnerTeam = team;
 
 					--Kill all enemies
 					for actor in MovableMan.Actors do

--- a/Data/Base.rte/Activities/OneManArmyDiggers.lua
+++ b/Data/Base.rte/Activities/OneManArmyDiggers.lua
@@ -219,7 +219,7 @@ end
 
 function OneManArmy:UpdateActivity()
 	if self.ActivityState ~= Activity.OVER then
-		ActivityMan:GetActivity():SetTeamFunds(0,0);
+		ActivityMan:GetActivity():SetTeamFunds(0, Activity.TEAM_1);
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
 				--Display messages.
@@ -229,7 +229,6 @@ function OneManArmy:UpdateActivity()
 					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
 				end
 
-				-- The current player's team
 				local team = self:GetTeamOfPlayer(player);
 				-- Check if any player's brain is dead
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
@@ -242,8 +241,6 @@ function OneManArmy:UpdateActivity()
 						self.WinnerTeam = self:OtherTeam(team);
 						ActivityMan:EndActivity();
 					end
-				else
-					self.HuntPlayer = player;
 				end
 
 				--Check if the player has won.
@@ -252,7 +249,7 @@ function OneManArmy:UpdateActivity()
 					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
 
-					self.WinnerTeam = player;
+					self.WinnerTeam = team;
 
 					--Kill all enemies.
 					for actor in MovableMan.Actors do


### PR DESCRIPTION
BrainVsBrain.lua had a hardcoded reference to the base brainbot when creating the AI brain. Human brains, on the other hand, would pick a random brain from the appropriate tech. While both could've been changed to pick a random brain, I thought it made more sense to do what other activities do and use the Infantry Brain preset (subtracting the Constructor) and only fall back to a random brain if `techID == -1` or the loadout can't be found.

OneManArmy and OneManArmyDiggers set `self.WinnerTeam = player` instead of `self.WinnerTeam = team`, which could cause issues with players other than 1. Additionally, both used a hardcoded team index 0 instead of `Activity.TEAM_1` when clearing the players' funds. OneManArmyDiggers also had a redundant comment and unused variable that I removed.