### PR TITLE
Exposed EffectAlwaysShows to Lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+<details><summary><b>Added</b></summary>
+
+- Exposed `MovableObject` INI property `EffectAlwaysShows` to Lua (R/W), boolean.
+
+</details>
+
 <details><summary><b>Fixed</b></summary>
 
 - Fixed regression introduced in 6.1 causing Conquest activities to immediately fail if a defending brain was present (and probably breaking other activities as well).

--- a/Source/Entities/MovableObject.h
+++ b/Source/Entities/MovableObject.h
@@ -434,8 +434,16 @@ namespace RTE {
 		bool GetPostEffectEnabled() const { return m_PostEffectEnabled; }
 
 		/// Sets whether or not to draw this MovableObject's effect every frame.
-		/// @param Boolean indicating whether or not to draw the effect.
+		/// @param newValue Boolean indicating whether or not to draw the effect.
 		void SetPostEffectEnabled(bool newValue) { m_PostEffectEnabled = newValue; }
+
+		/// Gets whether or not this MovableObject's effect can be obscured.
+		/// @return Boolean indicating whether or not the effect can be obscured.
+		bool GetEffectAlwaysShows() const { return m_EffectAlwaysShows; }
+
+		/// Sets whether or not this MovableObject's effect can be obscured.
+		/// @param newValue Boolean indicating whether or not the effect can be obscured.
+		void SetEffectAlwaysShows(bool newValue) { m_EffectAlwaysShows = newValue; }
 
 		/// Sets the current angular velocity of this MovableObject. Positive is
 		/// a counter clockwise rotation.

--- a/Source/Lua/LuaBindingsEntities.cpp
+++ b/Source/Lua/LuaBindingsEntities.cpp
@@ -890,6 +890,7 @@ LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, MovableObject) {
 	    .property("Diameter", &MovableObject::GetDiameter)
 	    .property("Scale", &MovableObject::GetScale, &MovableObject::SetScale)
 	    .property("EffectRotAngle", &MovableObject::GetEffectRotAngle, &MovableObject::SetEffectRotAngle)
+	    .property("EffectAlwaysShows", &MovableObject::GetEffectAlwaysShows, &MovableObject::SetEffectAlwaysShows)
 	    .property("EffectStartStrength", &MovableObject::GetEffectStartStrengthFloat, &MovableObject::SetEffectStartStrengthFloat)
 	    .property("EffectStopStrength", &MovableObject::GetEffectStopStrengthFloat, &MovableObject::SetEffectStopStrengthFloat)
 	    .property("GlobalAccScalar", &MovableObject::GetGlobalAccScalar, &MovableObject::SetGlobalAccScalar)


### PR DESCRIPTION
`EffectAlwaysShows` is necessary for most MOSR's to show their glows at all, and this would permit adding visible glows to MOSR's that otherwise lack this property.