### PR TITLE
Revert 'Metafight shouldn't be so reliant on Base craft' commit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+<details><summary><b>Changed</b></summary>
+
+- Conquest activities will once again fall-back to using base dropships and rockets if a random selection of the selected tech's craft can't find one capable of carrying passengers and/or cargo.
+
+</details>
+
 ## [Release v6.2.2] - 2024/02/24
 
 <details><summary><b>Added</b></summary>
@@ -26,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed the Conquest start game menu not letting you immediately start a game until you tweak some settings.
 
-- Fixed potential issues with One Man Army (and Diggers Only) that could occur when the player is not assigned to the first team.
+- Fixed potential issues with One Man Army (and Diggers Only) that could occur when using a different player than player 1.
 
 </details>
 

--- a/Data/Base.rte/Activities/MetaFight.lua
+++ b/Data/Base.rte/Activities/MetaFight.lua
@@ -1368,9 +1368,9 @@ function MetaFight:PickCraft(MetaPlayer)
 	-- Use base crafts as a fall-back
 	if not Craft then
 		if math.random() < 0.5 then
-			Craft = RandomACDropShip("Craft", MetaPlayer.NativeTechModule);
+			Craft = RandomACDropShip("Craft", "Base.rte");
 		else
-			Craft = RandomACRocket("Craft", MetaPlayer.NativeTechModule);
+			Craft = RandomACRocket("Craft", "Base.rte");
 		end
 	end
 
@@ -1406,9 +1406,9 @@ function MetaFight:OrderHeavyLoadout(player, team)
 			craftMaxMass = math.huge;
 		elseif craftMaxMass < 1 then
 			if math.random() < 0.5 then
-				Craft = RandomACDropShip("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACDropShip("Craft", "Base.rte");
 			else
-				Craft = RandomACRocket("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACRocket("Craft", "Base.rte");
 			end
 			craftMaxMass = Craft.MaxInventoryMass;
 		end
@@ -1467,9 +1467,9 @@ function MetaFight:OrderMediumLoadout(player, team)
 			craftMaxMass = math.huge;
 		elseif craftMaxMass < 1 then
 			if math.random() < 0.5 then
-				Craft = RandomACDropShip("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACDropShip("Craft", "Base.rte");
 			else
-				Craft = RandomACRocket("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACRocket("Craft", "Base.rte");
 			end
 			craftMaxMass = Craft.MaxInventoryMass;
 		end
@@ -1528,9 +1528,9 @@ function MetaFight:OrderLightLoadout(player, team)
 			craftMaxMass = math.huge;
 		elseif craftMaxMass < 1 then
 			if math.random() < 0.5 then
-				Craft = RandomACDropShip("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACDropShip("Craft", "Base.rte");
 			else
-				Craft = RandomACRocket("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACRocket("Craft", "Base.rte");
 			end
 			craftMaxMass = Craft.MaxInventoryMass;
 		end
@@ -1583,9 +1583,9 @@ function MetaFight:OrderScoutLoadout(player, team)
 			craftMaxMass = math.huge;
 		elseif craftMaxMass < 1 then
 			if math.random() < 0.5 then
-				Craft = RandomACDropShip("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACDropShip("Craft", "Base.rte");
 			else
-				Craft = RandomACRocket("Craft", MetaPlayer.NativeTechModule);
+				Craft = RandomACRocket("Craft", "Base.rte");
 			end
 			craftMaxMass = Craft.MaxInventoryMass;
 		end


### PR DESCRIPTION
In ceb1e773204350f0fa4246d6e9f2fc3bab6a161d, some hardcoded references to "Base.rte" in MetaFight.lua were changed to use `MetaPlayer.NativeTechModule`. However, each of these references were intended as a fallback, in case the module's own craft were unable to carry passengers or cargo, and as such, really should be referencing "Base.rte" instead.