### PR TITLE
Missing codeSequence table

### DIFF
--- a/Data/Base.rte/Scripts/Shared/SecretCodeEntry.lua
+++ b/Data/Base.rte/Scripts/Shared/SecretCodeEntry.lua
@@ -59,6 +59,9 @@ function SecretCodeEntry.Setup(callbackFunction, callbackSelfObject, codeSequenc
 	secretCodeEntryData.callbackSelfObject = callbackSelfObject;
 	secretCodeEntryData.codeSequenceOrCodeType = codeSequenceOrCodeType;
 	secretCodeEntryData.sequenceLength = sequenceLength;
+	if type(codeSequenceOrCodeType) == "table" then
+		secretCodeEntryData.codeSequence = codeSequenceOrCodeType;
+	end
 	secretCodeEntryData.firstEntrySoundContainer = firstEntrySoundContainer or SecretCodeEntry.defaultFirstEntrySoundContainer;
 	secretCodeEntryData.correctEntrySoundContainer = correctEntrySoundContainer or SecretCodeEntry.defaultCorrectEntrySoundContainer;
 	secretCodeEntryData.incorrectEntrySoundContainer = incorrectEntrySoundContainer or SecretCodeEntry.defaultIncorrectEntrySoundContainer;


### PR DESCRIPTION
Fixes an issue with **codeSequence** not being initialized thus causing an issue in the Update function on **line 99**
This is because the **codeSequenceOrCodeType** argument in **SecretCodeEntry.Setup()** function accepts either a number or table
But since the table doesn't get assigned to **codeSequence** (as it doesn't exist at all), it results in it being a nil value