### PR TITLE
Fix index 255 showing up as black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 </details>
 
+<details><summary><b>Fixed</b></summary>
+
+- Fixed an issue where palette index 255 was incorrectly showing as black.
+
+</details>
+
 ## [Release v6.2.2] - 2024/02/24
 
 <details><summary><b>Added</b></summary>

--- a/Source/Managers/PostProcessMan.cpp
+++ b/Source/Managers/PostProcessMan.cpp
@@ -125,6 +125,8 @@ void PostProcessMan::CreateGLBackBuffers() {
 	GL_CHECK(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, c_PaletteEntriesNumber, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0));
 	GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
 	GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+	GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+	GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
 	UpdatePalette();
 	GL_CHECK(glActiveTexture(GL_TEXTURE0));
 	m_ProjectionMatrix = std::make_unique<glm::mat4>(glm::ortho(0.0F, static_cast<float>(g_WindowMan.GetResX()), 0.0F, static_cast<float>(g_WindowMan.GetResY()), -1.0F, 1.0F));


### PR DESCRIPTION
- index 255 shows up black as the uv index goes to 1.0 which is past the edge of the palette texture. so make the palette wrap clamp to edge

- Does not fix allegro using weird 18bit color which subtly changes the palette.
- Also does not fix the palette mismatch between palette.bmp and (from what I can find) most or all sprites in data (palette.bmp has darker colors than the palette used by the sprites.)