### PR TITLE
Fix registered drawings for MOSRotating

### DIFF
--- a/Source/Entities/MOSRotating.cpp
+++ b/Source/Entities/MOSRotating.cpp
@@ -1678,7 +1678,7 @@ void MOSRotating::Draw(BITMAP* pTargetBitmap, const Vector& targetPos, DrawMode 
 			for (int i = 0; i < passes; ++i) {
 				int spriteX = aDrawPos[i].GetFloorIntX();
 				int spriteY = aDrawPos[i].GetFloorIntY();
-				g_SceneMan.RegisterDrawing(pTargetBitmap, m_MOID, spriteX + m_SpriteOffset.m_X - (m_SpriteRadius * m_Scale), spriteY + m_SpriteOffset.m_Y - (m_SpriteRadius * m_Scale), spriteX - m_SpriteOffset.m_X + (m_SpriteRadius * m_Scale), spriteY - m_SpriteOffset.m_Y + (m_SpriteRadius * m_Scale));
+				g_SceneMan.RegisterDrawing(pTargetBitmap, m_MOID, spriteX - (m_SpriteRadius * m_Scale), spriteY - (m_SpriteRadius * m_Scale), spriteX + (m_SpriteRadius * m_Scale), spriteY + (m_SpriteRadius * m_Scale));
 				if (mode == g_DrawMOID) {
 					continue;
 				}
@@ -1708,7 +1708,7 @@ void MOSRotating::Draw(BITMAP* pTargetBitmap, const Vector& targetPos, DrawMode 
 			for (int i = 0; i < passes; ++i) {
 				int spriteX = aDrawPos[i].GetFloorIntX();
 				int spriteY = aDrawPos[i].GetFloorIntY();
-				g_SceneMan.RegisterDrawing(pTargetBitmap, m_MOID, spriteX + m_SpriteOffset.m_X - (m_SpriteRadius * m_Scale), spriteY + m_SpriteOffset.m_Y - (m_SpriteRadius * m_Scale), spriteX - m_SpriteOffset.m_X + (m_SpriteRadius * m_Scale), spriteY - m_SpriteOffset.m_Y + (m_SpriteRadius * m_Scale));
+				g_SceneMan.RegisterDrawing(pTargetBitmap, m_MOID, spriteX - (m_SpriteRadius * m_Scale), spriteY - (m_SpriteRadius * m_Scale), spriteX + (m_SpriteRadius * m_Scale), spriteY + (m_SpriteRadius * m_Scale));
 				if (mode == g_DrawMOID) {
 					continue;
 				}


### PR DESCRIPTION
Make the registered drawing for MOSRotating just a square of spriteradius length around the pivot, instead of whatever the code was trying before. (I *think* it was trying something clever with an offset rectangle maybe? Possibly assuming that sprite offsets are reasonable and fall within the sprite bounds?)