### PR TITLE
Fix meson deprecation warning

### DIFF
--- a/external/include/meson.build
+++ b/external/include/meson.build
@@ -6,6 +6,8 @@ external_inc_dirs = [include_directories('boost_1_75',
                                          'thread-pool-3.5.0/include',
                                          'hopscotch-map-2.3.1/include',)]
 if host_machine.system() in ['linux', 'darwin']
+  luajit_proj = subproject('LuaJIT-2.1', default_options: ['header_only=true'])
+  external_inc_dirs += luajit_proj.get_variable('luajit_source_dir')
 endif
 if host_machine.system() == 'windows'
   external_inc_dirs += include_directories('LZ4-1.9.3/LZ4',)

--- a/external/meson.build
+++ b/external/meson.build
@@ -1,4 +1,3 @@
 subdir('include')
 subdir('lib')
 subdir('sources')
-external_inc_dirs += include_directories('sources/LuaJIT-2.1/src')

--- a/external/sources/LuaJIT-2.1/meson.build
+++ b/external/sources/LuaJIT-2.1/meson.build
@@ -42,5 +42,5 @@ luajit_dep = declare_dependency(
     link_args: lj_linkargs,
 )
 
-#meson.override_dependency('luajit', luajit_dep)
+meson.override_dependency('luajit', luajit_dep)
 endif

--- a/external/sources/LuaJIT-2.1/meson.build
+++ b/external/sources/LuaJIT-2.1/meson.build
@@ -1,6 +1,8 @@
 # Meson files from github.com/franko/luajit
 project('luajit', 'c', version : '2.0.5', default_options : ['c_winlibs='])
-
+if get_option('header_only')
+  luajit_source_dir = include_directories('src')
+else
 pkg = import('pkgconfig')
 
 cc = meson.get_compiler('c')
@@ -21,6 +23,7 @@ if not get_option('use_prebuilt_libraries') or host_machine.system() in ['darwin
         c_args: lj_defines,
         name_prefix: lj_libprefix,
         dependencies: luajit_dependencies,
+        build_by_default: false,
         install: true
     )
 else
@@ -39,11 +42,5 @@ luajit_dep = declare_dependency(
     link_args: lj_linkargs,
 )
 
-meson.override_dependency('luajit', luajit_dep)
-
-pkg.generate(libluajit,
-    filebase : 'luajit',
-    name : 'LuaJIT',
-    description : 'Just-in-time compiler for Lua',
-    url : 'http://luajit.org',
-)
+#meson.override_dependency('luajit', luajit_dep)
+endif

--- a/external/sources/LuaJIT-2.1/meson_options.txt
+++ b/external/sources/LuaJIT-2.1/meson_options.txt
@@ -1,2 +1,3 @@
 
 option('use_prebuilt_libraries', type: 'boolean', value: true, yield: true, description: 'On windows use the prebuilt libraries')
+option('header_only', type: 'boolean', value: false, description: 'Only expose the header files')

--- a/external/sources/LuaJIT-2.1/src/host/meson.build
+++ b/external/sources/LuaJIT-2.1/src/host/meson.build
@@ -36,6 +36,7 @@ buildvm = executable('buildvm',
     include_directories: luajit_source_dir,
     c_args: buildvm_defines,
     dependencies: libm,
+    build_by_default: false,
     install: false,
     native: true
 )

--- a/external/sources/LuaJIT-2.1/src/meson.build
+++ b/external/sources/LuaJIT-2.1/src/meson.build
@@ -148,7 +148,7 @@ endforeach
 vmdef = custom_target('vmdef.lua',
     input : ljlib_sources,
     output : 'vmdef.lua',
-    build_by_default : true,
+    build_by_default : false,
     install: true,
     install_dir: jitlib_install_dir,
     command : [buildvm, '-m', 'vmdef', '-o', '@OUTPUT@', '@INPUT@']

--- a/meson.build
+++ b/meson.build
@@ -212,7 +212,7 @@ elif host_machine.system() == 'windows'
   sdl2 = subproject('SDL2-2.26.3')
   sdl2_dep = dependency('sdl2')
   luajit = subproject('LuaJIT-2.1')
-  luajit_dep = dependency('luajit')
+  luajit_dep = luajit.get_variable(luajit_dep)
   zlib = subproject('zlib-ng-2.1.3')
   zlib_dep = dependency('zlib')
   minizip = subproject('minizip-ng-4.0.0')

--- a/meson.build
+++ b/meson.build
@@ -212,7 +212,7 @@ elif host_machine.system() == 'windows'
   sdl2 = subproject('SDL2-2.26.3')
   sdl2_dep = dependency('sdl2')
   luajit = subproject('LuaJIT-2.1')
-  luajit_dep = luajit.get_variable(luajit_dep)
+  luajit_dep = dependency('luajit')
   zlib = subproject('zlib-ng-2.1.3')
   zlib_dep = dependency('zlib')
   minizip = subproject('minizip-ng-4.0.0')


### PR DESCRIPTION
this is somehow even more hacky than what I was doing before, but it works without meson complaining about sandbox violations