### PR TITLE
Activities: More player/screen mixup fixes, Decision Day typo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 </details>
 
-<details><summary><b>Removed</b></summary>
-
-</details>
-
 <details><summary><b>Fixed</b></summary>
 
 - Fixed an issue where palette index 255 was incorrectly showing as black.
+
+- Fixed instances of `CameraMan:GetScrollTarget()` and `CameraMan:SetScrollTarget()` supplying a player index instead of a screen index.
+
+- Fixed a bug in Decision Day that could cause an error when trying to set the camera's scroll target, in addition to the previous issue.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed an issue where palette index 255 was incorrectly showing as black.
 
-- Fixed instances of `CameraMan:GetScrollTarget()` and `CameraMan:SetScrollTarget()` supplying a player index instead of a screen index.
+- Fixed instances of `CameraMan:GetScrollTarget()` and `CameraMan:SetScrollTarget()` supplying a player index instead of a screen index. This could prevent the functions from working properly, or at all, when playing as a player other than 1, potentially screwing up camera effects.
 
 - Fixed a bug in Decision Day that could cause an error when trying to set the camera's scroll target, in addition to the previous issue.
 

--- a/Data/Base.rte/Activities/BrainVsBrain.lua
+++ b/Data/Base.rte/Activities/BrainVsBrain.lua
@@ -407,8 +407,9 @@ function BrainvsBrain:UpdateActivity()
 							end
 						else
 							self:ResetMessageTimer(player);
-							FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-							FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 2000, -1, false);
+							local screen = self:ScreenOfPlayer(player);
+							FrameMan:ClearScreenText(screen);
+							FrameMan:SetScreenText("Your brain has been destroyed!", screen, 2000, -1, false);
 						end
 					end
 				end

--- a/Data/Base.rte/Activities/Harvester.lua
+++ b/Data/Base.rte/Activities/Harvester.lua
@@ -155,11 +155,12 @@ function Harvester:UpdateActivity()
 
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
+				local screen = self:ScreenOfPlayer(player);
 				--Display messages.
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(self.goldNeeded - (math.ceil(self:GetTeamFunds(Activity.TEAM_1)) - self.humanTeamFundsAfterInitialEditingPhase) .. " oz of gold left", self:ScreenOfPlayer(player), 0, 1000, false);
+					FrameMan:SetScreenText(self.goldNeeded - (math.ceil(self:GetTeamFunds(Activity.TEAM_1)) - self.humanTeamFundsAfterInitialEditingPhase) .. " oz of gold left", screen, 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Dig up " .. self.goldDisplay .. " oz of gold!", self:ScreenOfPlayer(player), 333, 5000, true);
+					FrameMan:SetScreenText("Dig up " .. self.goldDisplay .. " oz of gold!", screen, 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -179,8 +180,8 @@ function Harvester:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -191,8 +192,8 @@ function Harvester:UpdateActivity()
 				--Check if the player has won.
 				if self:GetTeamFunds(Activity.TEAM_1) - self.humanTeamFundsAfterInitialEditingPhase > self.goldNeeded then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("You dug up all the gold!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("You dug up all the gold!", screen, 333, -1, false);
 
 					self.WinnerTeam = Activity.TEAM_1;
 

--- a/Data/Base.rte/Activities/KeepieUppie.lua
+++ b/Data/Base.rte/Activities/KeepieUppie.lua
@@ -138,13 +138,14 @@ function KeepieUppie:UpdateActivity()
 		if self.ActivityState ~= Activity.OVER and self.ActivityState ~= Activity.EDITING then
 			for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 				if self:PlayerActive(player) and self:PlayerHuman(player) then
+					local screen = self:ScreenOfPlayer(player);
 					--Display messages.
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					FrameMan:ClearScreenText(screen);
 					if self.startMessageTimer:IsPastSimMS(3000) then
-						FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
+						FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", screen, 0, 1000, false);
 					else
-						FrameMan:SetScreenText("Keep the rocket alive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
+						FrameMan:SetScreenText("Keep the rocket alive for " .. self.timeDisplay .. "!", screen, 333, 5000, true);
 					end
 
 					-- The current player's team
@@ -153,8 +154,8 @@ function KeepieUppie:UpdateActivity()
 					if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 						self:SetPlayerBrain(nil, player);
 						self:ResetMessageTimer(player);
-						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-						FrameMan:SetScreenText("Your rocket has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+						FrameMan:ClearScreenText(screen);
+						FrameMan:SetScreenText("Your rocket has been destroyed!", screen, 333, -1, false);
 						-- Now see if all brains of self player's team are dead, and if so, end the game
 						if not MovableMan:GetFirstBrainActor(team) then
 							self.WinnerTeam = self:OtherTeam(team);
@@ -167,8 +168,8 @@ function KeepieUppie:UpdateActivity()
 					--Check if the player has won.
 					if self.winTimer:IsPastSimMS(self.timeLimit) then
 						self:ResetMessageTimer(player);
-						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-						FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
+						FrameMan:ClearScreenText(screen);
+						FrameMan:SetScreenText("You survived!", screen, 333, -1, false);
 
 						self.WinnerTeam = player;
 

--- a/Data/Base.rte/Activities/Massacre.lua
+++ b/Data/Base.rte/Activities/Massacre.lua
@@ -147,15 +147,16 @@ function Massacre:UpdateActivity()
 		end
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
+				local screen = self:ScreenOfPlayer(player);
 				--Display messages.
 				if self.startMessageTimer:IsPastSimMS(3000) then
 					if self.killsNeeded - self:GetTeamDeathCount(Activity.TEAM_2) > 1 then
-						FrameMan:SetScreenText(self.killsNeeded - self:GetTeamDeathCount(Activity.TEAM_2) .. " enemies left!", self:ScreenOfPlayer(player), 0, 1000, false);
+						FrameMan:SetScreenText(self.killsNeeded - self:GetTeamDeathCount(Activity.TEAM_2) .. " enemies left!", screen, 0, 1000, false);
 					else
-						FrameMan:SetScreenText("1 enemy left!", self:ScreenOfPlayer(player), 0, 1000, false);
+						FrameMan:SetScreenText("1 enemy left!", screen, 0, 1000, false);
 					end
 				else
-					FrameMan:SetScreenText("Kill " .. self.killsDisplay .. " enemies!", self:ScreenOfPlayer(player), 333, 5000, true);
+					FrameMan:SetScreenText("Kill " .. self.killsDisplay .. " enemies!", screen, 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -175,8 +176,8 @@ function Massacre:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -187,8 +188,8 @@ function Massacre:UpdateActivity()
 				--Check if the player has won.
 				if self:GetTeamDeathCount(Activity.TEAM_2) >= self.killsNeeded then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("You killed all the attackers!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("You killed all the attackers!", screen, 333, -1, false);
 
 					self.WinnerTeam = Activity.TEAM_1;
 

--- a/Data/Base.rte/Activities/MetaFight.lua
+++ b/Data/Base.rte/Activities/MetaFight.lua
@@ -742,8 +742,9 @@ function MetaFight:UpdateActivity()
 				local team = self:GetTeamOfPlayer(player);
 	--				if (self.ActivityState == Activity.RUNNING) then
 				if (SceneMan.Scene:IsScanScheduled(team)) then
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText(scanMessage, self:ScreenOfPlayer(player), messageBlink, 8000, false);
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText(scanMessage, screen, messageBlink, 8000, false);
 				end
 			end
 		end
@@ -823,9 +824,10 @@ function MetaFight:UpdateActivity()
 						self:SetObservationTarget(self:GetPlayerBrain(player).Pos, player);
 						-- Clear the messages before starting the game
 						self:ResetMessageTimer(player);
-						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+						local screen = self:ScreenOfPlayer(player);
+						FrameMan:ClearScreenText(screen);
 						-- Reset the screen occlusion if any players are still in menus
-						CameraMan:SetScreenOcclusion(Vector(), self:ScreenOfPlayer(player));
+						CameraMan:SetScreenOcclusion(Vector(), screen);
 					end
 				end
 			end

--- a/Data/Base.rte/Activities/OneManArmy.lua
+++ b/Data/Base.rte/Activities/OneManArmy.lua
@@ -256,11 +256,12 @@ function OneManArmy:UpdateActivity()
 		ActivityMan:GetActivity():SetTeamFunds(0, Activity.TEAM_1);
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
+				local screen = self:ScreenOfPlayer(player);
 				--Display messages
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
+					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", screen, 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", screen, 333, 5000, true);
 				end
 
 				local team = self:GetTeamOfPlayer(player);
@@ -268,8 +269,8 @@ function OneManArmy:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 333, -1, false);
 					--Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -280,8 +281,8 @@ function OneManArmy:UpdateActivity()
 				--Check if the player has won
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("You survived!", screen, 333, -1, false);
 
 					self.WinnerTeam = team;
 

--- a/Data/Base.rte/Activities/OneManArmyDiggers.lua
+++ b/Data/Base.rte/Activities/OneManArmyDiggers.lua
@@ -220,11 +220,12 @@ function OneManArmy:UpdateActivity()
 		ActivityMan:GetActivity():SetTeamFunds(0, Activity.TEAM_1);
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
+				local screen = self:ScreenOfPlayer(player);
 				--Display messages.
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
+					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000) .. " seconds left", screen, 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", screen, 333, 5000, true);
 				end
 
 				local team = self:GetTeamOfPlayer(player);
@@ -232,8 +233,8 @@ function OneManArmy:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -244,8 +245,8 @@ function OneManArmy:UpdateActivity()
 				--Check if the player has won.
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("You survived!", screen, 333, -1, false);
 
 					self.WinnerTeam = team;
 

--- a/Data/Base.rte/Activities/OneManArmyZeroG.lua
+++ b/Data/Base.rte/Activities/OneManArmyZeroG.lua
@@ -285,11 +285,12 @@ function OneManArmyZeroG:UpdateActivity()
 		ActivityMan:GetActivity():SetTeamFunds(0, 0);
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
+				local screen = self:ScreenOfPlayer(player);
 				--Display messages
 				if self.startMessageTimer:IsPastSimMS(3000) then
-					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
+					FrameMan:SetScreenText(math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) * 0.001) .. " seconds left", screen, 0, 1000, false);
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", screen, 333, 5000, true);
 				end
 
 				local team = self:GetTeamOfPlayer(player);
@@ -297,8 +298,8 @@ function OneManArmyZeroG:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 333, -1, false);
 					--Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -309,8 +310,8 @@ function OneManArmyZeroG:UpdateActivity()
 				--Check if the player has won
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("You survived!", screen, 333, -1, false);
 
 					self.WinnerTeam = player;
 

--- a/Data/Base.rte/Activities/Prospecting.lua
+++ b/Data/Base.rte/Activities/Prospecting.lua
@@ -136,8 +136,9 @@ function Prospecting:UpdateActivity()
 				-- The current player's team
 				local team = self:GetTeamOfPlayer(player);
 				if (self.ActivityState == Activity.STARTING) then
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText(scanMessage, self:ScreenOfPlayer(player), messageBlink, 8000, true);
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText(scanMessage, screen, messageBlink, 8000, true);
 				end
 			end
 		end

--- a/Data/Base.rte/Activities/Siege.lua
+++ b/Data/Base.rte/Activities/Siege.lua
@@ -319,8 +319,9 @@ function Siege:UpdateActivity()
 					-- self:AddObjectivePoint("Protect!", Brain.AboveHUDPos, self.PlayerTeam, GameActivity.ARROWDOWN);
 				else
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 2000, -1, false);
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 2000, -1, false);
 				end
 			end
 		end

--- a/Data/Base.rte/Activities/SiteScan.lua
+++ b/Data/Base.rte/Activities/SiteScan.lua
@@ -159,8 +159,9 @@ function SiteScan:UpdateActivity()
 				-- The current player's team
 				local team = self:GetTeamOfPlayer(player);
 				if (self.ActivityState == Activity.RUNNING) then
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText(scanMessage, self:ScreenOfPlayer(player), messageBlink, 8000, true);
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText(scanMessage, screen, messageBlink, 8000, true);
 				end
 			end
 		end

--- a/Data/Base.rte/Activities/SkirmishDefense.lua
+++ b/Data/Base.rte/Activities/SkirmishDefense.lua
@@ -329,8 +329,9 @@ function SkirmishDefense:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 333, -1, false);
 				else
 					playertally = playertally + 1;
 					if not setTeam[team] then

--- a/Data/Base.rte/Activities/Survival.lua
+++ b/Data/Base.rte/Activities/Survival.lua
@@ -138,16 +138,17 @@ function Survival:UpdateActivity()
 		end
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
+				local screen = self:ScreenOfPlayer(player);
 				--Display messages.
 				if self.startMessageTimer:IsPastSimMS(3000) then
 					local secondsLeft = math.floor(self.winTimer:LeftTillSimMS(self.timeLimit) / 1000);
 					if (secondsLeft > 1) then
-						FrameMan:SetScreenText(secondsLeft .. " seconds left", self:ScreenOfPlayer(player), 0, 1000, false);
+						FrameMan:SetScreenText(secondsLeft .. " seconds left", screen, 0, 1000, false);
 					else
-						FrameMan:SetScreenText("1 second left!", self:ScreenOfPlayer(player), 0, 1000, false);
+						FrameMan:SetScreenText("1 second left!", screen, 0, 1000, false);
 					end
 				else
-					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", self:ScreenOfPlayer(player), 333, 5000, true);
+					FrameMan:SetScreenText("Survive for " .. self.timeDisplay .. "!", screen, 333, 5000, true);
 				end
 
 				-- The current player's team
@@ -167,8 +168,8 @@ function Survival:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been destroyed!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been destroyed!", screen, 333, -1, false);
 					-- Now see if all brains of self player's team are dead, and if so, end the game
 					if not MovableMan:GetFirstBrainActor(team) then
 						self.WinnerTeam = self:OtherTeam(team);
@@ -181,8 +182,8 @@ function Survival:UpdateActivity()
 				--Check if the player has won.
 				if self.winTimer:IsPastSimMS(self.timeLimit) then
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("You survived!", self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("You survived!", screen, 333, -1, false);
 
 					self.WinnerTeam = Activity.TEAM_1;
 

--- a/Data/Base.rte/Activities/Utility/HUDHandler.lua
+++ b/Data/Base.rte/Activities/Utility/HUDHandler.lua
@@ -439,10 +439,11 @@ function HUDHandler:UpdateHUDHandler()
 				local pos = not cameraTable.Position.PresetName and cameraTable.Position or cameraTable.Position.Pos; -- severely ghetto mo check
 			
 				for k, player in pairs(self.saveTable.playersInTeamTables[team]) do
-					CameraMan:SetScrollTarget(pos, cameraTable.Speed, player);
+					local screen = self.Activity:ScreenOfPlayer(player);
+					CameraMan:SetScrollTarget(pos, cameraTable.Speed, screen);
 					self.Activity:SetViewState(Activity.OBSERVE, player);
 					if cameraTable.disableHUDFully then
-						FrameMan:SetHudDisabled(true, self.Activity:ScreenOfPlayer(player));
+						FrameMan:SetHudDisabled(true, screen);
 						disableDrawingObjectives = true;
 					end
 				end
@@ -482,16 +483,17 @@ function HUDHandler:UpdateHUDHandler()
 		else -- enforce min/max limits
 		
 			for k, player in pairs(self.saveTable.playersInTeamTables[team]) do
+				local screen = self.Activity:ScreenOfPlayer(player);
 				if self.saveTable.teamTables[team].cameraMinimumX then
 					local adjustedCameraMinimumX = self.saveTable.teamTables[team].cameraMinimumX + (0.5 * (FrameMan.PlayerScreenWidth - 960))
-					if CameraMan:GetScrollTarget(player).X < adjustedCameraMinimumX then
-						CameraMan:SetScrollTarget(Vector(adjustedCameraMinimumX, CameraMan:GetScrollTarget(player).Y), 0.25, player);
+					if CameraMan:GetScrollTarget(screen).X < adjustedCameraMinimumX then
+						CameraMan:SetScrollTarget(Vector(adjustedCameraMinimumX, CameraMan:GetScrollTarget(screen).Y), 0.25, screen);
 					end
 				end
 			
 				if self.saveTable.teamTables[team].cameraMaximumX then
-					if CameraMan:GetScrollTarget(player).X > self.saveTable.teamTables[team].cameraMaximumX then
-						CameraMan:SetScrollTarget(Vector(self.saveTable.teamTables[team].cameraMaximumX, CameraMan:GetScrollTarget(player).Y), 0.25, player);
+					if CameraMan:GetScrollTarget(screen).X > self.saveTable.teamTables[team].cameraMaximumX then
+						CameraMan:SetScrollTarget(Vector(self.saveTable.teamTables[team].cameraMaximumX, CameraMan:GetScrollTarget(screen).Y), 0.25, screen);
 					end
 				end
 			end

--- a/Data/Base.rte/Activities/WaveDefense.lua
+++ b/Data/Base.rte/Activities/WaveDefense.lua
@@ -337,9 +337,10 @@ function WaveDefense:UpdateActivity()
 				if not MovableMan:IsActor(self:GetPlayerBrain(player)) then
 					self:SetPlayerBrain(nil, player);
 					self:ResetMessageTimer(player);
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
 					local str = "Your brain has been destroyed on wave "..self.wave.." at "..self.Difficulty.."% difficulty";
-					FrameMan:SetScreenText(str, self:ScreenOfPlayer(player), 333, -1, false);
+					FrameMan:SetScreenText(str, screen, 333, -1, false);
 				else
 					playertally = playertally + 1;
 					if not setTeam[team] then

--- a/Data/Base.rte/Scenes/Objects/Bunkers/BunkerSystems/Automovers/Controller/Controller.lua
+++ b/Data/Base.rte/Scenes/Objects/Bunkers/BunkerSystems/Automovers/Controller/Controller.lua
@@ -86,7 +86,7 @@ function Create(self)
 
 	for actor in MovableMan.Actors do
 		if actor.PresetName:find("Automover Controller") and actor.Team == self.Team and actor.UniqueID ~= self.UniqueID then
-			ActivityMan:GetActivity():SetTeamFunds(ActivityMan:GetActivity():GetTeamFunds(self.Team) + actor:GetGoldValue(0, 0), self.Team);
+			self.currentActivity:SetTeamFunds(self.currentActivity:GetTeamFunds(self.Team) + actor:GetGoldValue(0, 0), self.Team);
 			actor.ToDelete = true;
 		end
 	end
@@ -1082,9 +1082,10 @@ automoverActorFunctions.chooseTeleporterForPlayerControlledActor = function(self
 		end
 
 		local player = actorController.Player;
-		CameraMan:SetScrollTarget(manualTeleporterData.sortedTeleporters[manualTeleporterData.currentChosenTeleporter].node.Pos, 1, player);
-		FrameMan:ClearScreenText(player);
-		FrameMan:SetScreenText("CHOOSING TELEPORTER: Move Left or Right to change teleporter. Press Fire to teleport. Open the Pie Menu to cancel.", player, 0, 100, false);
+		local screen = self.currentActivity:ScreenOfPlayer(player);
+		CameraMan:SetScrollTarget(manualTeleporterData.sortedTeleporters[manualTeleporterData.currentChosenTeleporter].node.Pos, 1, screen);
+		FrameMan:ClearScreenText(screen);
+		FrameMan:SetScreenText("CHOOSING TELEPORTER: Move Left or Right to change teleporter. Press Fire to teleport. Open the Pie Menu to cancel.", screen, 0, 100, false);
 	else
 		self:changeScaleOfMOSRotatingAndAttachables(actor, (manualTeleporterData.actorTeleportationStage == 2 and manualTeleporterData.teleporterVisualsTimer.SimTimeLimitProgress or 1 - manualTeleporterData.teleporterVisualsTimer.SimTimeLimitProgress));
 		self:centreActorToClosestNodeIfMovingInAppropriateDirection(actorData, true);

--- a/Data/Base.rte/Scripts/Shared/SecretCodeEntry.lua
+++ b/Data/Base.rte/Scripts/Shared/SecretCodeEntry.lua
@@ -93,6 +93,7 @@ function SecretCodeEntry.Update(secretCodeEntryDataIndex)
 	local playersWhoCompletedCode = {};
 	
 	if UInputMan:AnyPress() then
+		local activity = ActivityMan:GetActivity();
 		for player, inputData in pairs(secretCodeEntryData.inputs) do
 			local expectedNextControlState;
 			if type(secretCodeEntryData.codeSequenceOrCodeType) == "number" then
@@ -121,7 +122,7 @@ function SecretCodeEntry.Update(secretCodeEntryDataIndex)
 				inputData.currentStep = inputData.currentStep + 1;
 			end
 			if soundToPlay then
-				soundToPlay:Play(CameraMan:GetScrollTarget(inputData.controller.Player), inputData.controller.Player);
+				soundToPlay:Play(CameraMan:GetScrollTarget(activity:ScreenOfPlayer(inputData.controller.Player)), inputData.controller.Player);
 			end
 			
 			if inputData.currentStep == secretCodeEntryData.sequenceLength then

--- a/Data/Browncoats.rte/Scenes/Objects/BunkerSystems/RefineryAmbienceController/RefineryAmbienceController.lua
+++ b/Data/Browncoats.rte/Scenes/Objects/BunkerSystems/RefineryAmbienceController/RefineryAmbienceController.lua
@@ -1,5 +1,5 @@
 function Create(self)
-	local activity = ActivityMan:GetActivity();
+	self.activity = ActivityMan:GetActivity();
 	
 	print("Refinery Ambience Controller initialized")
 	
@@ -10,7 +10,7 @@ function Create(self)
 	self.playerIntOneShotContainers = {};
 	
 	for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
-		if activity:PlayerActive(player) and activity:PlayerHuman(player) then
+		if self.activity:PlayerActive(player) and self.activity:PlayerHuman(player) then
 			self.playerIndoornesses[player] = 0;
 			self.playerExtContainers[player] = CreateSoundContainer("Yskely Refinery Ambience Ext", "Browncoats.rte");
 			self.playerIntContainers[player] = CreateSoundContainer("Yskely Refinery Ambience Int", "Browncoats.rte");
@@ -39,7 +39,7 @@ function ThreadedUpdate(self)
 	self.ToDelete = false;
 
 	for player, indoorness in pairs(self.playerIndoornesses) do
-		local cursorPos = CameraMan:GetScrollTarget(player)
+		local cursorPos = CameraMan:GetScrollTarget(self.activity:ScreenOfPlayer(player))
 		
 		if SceneMan.Scene:WithinArea("IndoorArea", cursorPos) then		
 			self.playerIndoornesses[player] = math.min(1, indoorness + TimerMan.DeltaTimeSecs * 0.5);			

--- a/Data/Missions.rte/Activities/DecisionDay.lua
+++ b/Data/Missions.rte/Activities/DecisionDay.lua
@@ -992,8 +992,9 @@ end
 function DecisionDay:UpdateCamera()
 	for _, player in pairs(self.humanPlayers) do
 		local adjustedCameraMinimumX = self.cameraMinimumX + (0.5 * (FrameMan.PlayerScreenWidth - 960))
-		if CameraMan:GetScrollTarget(player).X < adjustedCameraMinimumX then
-			CameraMan:SetScrollTarget(Vector(adjustedCameraMinimumX, CameraMan:GetScrollTarget(player).Y), 0.25, 0);
+		local screen = self:ScreenOfPlayer(player);
+		if CameraMan:GetScrollTarget(screen).X < adjustedCameraMinimumX then
+			CameraMan:SetScrollTarget(Vector(adjustedCameraMinimumX, CameraMan:GetScrollTarget(screen).Y), 0.25, screen);
 		end
 	end
 	
@@ -1104,10 +1105,10 @@ function DecisionDay:UpdateCamera()
 			if not scrollTargetAndSpeed[1] then
 				brain = self:GetPlayerBrain(player)
 				if brain then
-					CameraMan:SetScrollTarget(brain.pos, scrollTargetAndSpeed[2], player)
+					CameraMan:SetScrollTarget(brain.Pos, scrollTargetAndSpeed[2], self:ScreenOfPlayer(player))
 				end
 			else
-				CameraMan:SetScrollTarget(scrollTargetAndSpeed[1], scrollTargetAndSpeed[2], player);
+				CameraMan:SetScrollTarget(scrollTargetAndSpeed[1], scrollTargetAndSpeed[2], self:ScreenOfPlayer(player));
 			end
 		end
 	end
@@ -1211,8 +1212,9 @@ function DecisionDay:UpdateMessages()
 		end
 
 		if messageText then
-			FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-			FrameMan:SetScreenText(messageText, self:ScreenOfPlayer(player), blinkTime, 0, textCentered);
+			local screen = self:ScreenOfPlayer(player);
+			FrameMan:ClearScreenText(screen);
+			FrameMan:SetScreenText(messageText, screen, blinkTime, 0, textCentered);
 		end
 	end
 end
@@ -1312,7 +1314,7 @@ function DecisionDay:UpdateObjectiveArrowsAndRegionVisuals()
 
 				for _, player in pairs(self.humanPlayers) do
 					if self:GetViewState(player) == Activity.ACTORSELECT then
-						if math.abs((bunkerRegionData.totalArea.Center - CameraMan:GetScrollTarget(player)).X) < FrameMan.PlayerScreenWidth * 0.75 then
+						if math.abs((bunkerRegionData.totalArea.Center - CameraMan:GetScrollTarget(self:ScreenOfPlayer(player))).X) < FrameMan.PlayerScreenWidth * 0.75 then
 							local boxFillPrimitives = {};
 							for box in bunkerRegionData.totalArea.Boxes do
 								boxFillPrimitives[#boxFillPrimitives + 1] = BoxFillPrimitive(player, box.Corner, box.Corner + Vector(box.Width, box.Height), bunkerRegionData.ownerTeam == self.humanTeam and 147 or 13);

--- a/Data/Missions.rte/Activities/Doainar.lua
+++ b/Data/Missions.rte/Activities/Doainar.lua
@@ -205,6 +205,7 @@ function DoainarMission:UpdateActivity()
 		-- Iterate through all human players
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
+				local screen = self:ScreenOfPlayer(player);
 				-- The current player's team
 				local team = self:GetTeamOfPlayer(player);
 				-- Make sure the game is not already ending
@@ -219,7 +220,7 @@ function DoainarMission:UpdateActivity()
 						self:SetPlayerBrain(newBrain, player);
 						self:SwitchToActor(newBrain, player, team);
 					else
-						FrameMan:SetScreenText("Your brain has been lost!", self:ScreenOfPlayer(player), 333, -1, true);
+						FrameMan:SetScreenText("Your brain has been lost!", screen, 333, -1, true);
 						self.brainDead[player] = true;
 						-- Now see if all brains of self player's team are dead, and if so, end the game
 						if not MovableMan:GetFirstBrainActor(team) then
@@ -245,8 +246,8 @@ function DoainarMission:UpdateActivity()
 								self.target = MovableMan:GetClosestTeamActor(self.PlayerTeam, Activity.PLAYER_NONE, self.mamaCrab.Pos, SceneMan.SceneWidth, Vector(), self.mamaCrab);
 
 								self:ResetMessageTimer(player);
-								FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-								FrameMan:SetScreenText("Uh oh, looks like you angered the mother crab!  Kill it before it kills you!", self:ScreenOfPlayer(player), 0, 7500, true);
+								FrameMan:ClearScreenText(screen);
+								FrameMan:SetScreenText("Uh oh, looks like you angered the mother crab!  Kill it before it kills you!", screen, 0, 7500, true);
 								MusicMan:PlayDynamicSong("Generic Boss Fight Music", "Default", true);
 							end
 						end
@@ -255,30 +256,30 @@ function DoainarMission:UpdateActivity()
 							self:SwitchToActor(brain, player, team);
 							self.brainHasLanded[player] = true;
 							self:ResetMessageTimer(player);
-							FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-							FrameMan:SetScreenText("Looks like there's a crab den down here.  We'll have to clear them out first.", self:ScreenOfPlayer(player), 0, 7500, true);
+							FrameMan:ClearScreenText(screen);
+							FrameMan:SetScreenText("Looks like there's a crab den down here.  We'll have to clear them out first.", screen, 0, 7500, true);
 						end
 
 						if not self.mamaCrab and self.mamaDead == false and self.mamaAggressive == true then
 							self.mamaDead = true;
 							self:ResetMessageTimer(player);
-							FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-							FrameMan:SetScreenText("That was a close one.  Go finish off their den!", self:ScreenOfPlayer(player), 0, 7500, true);
+							FrameMan:ClearScreenText(screen);
+							FrameMan:SetScreenText("That was a close one.  Go finish off their den!", screen, 0, 7500, true);
 							MusicMan:PlayDynamicSong("Generic Ambient Music", "Default", true);
 						end
 
 						if MovableMan:IsParticle(self.eggSac) == false and self.sacDestroyed == false then
 							self:ResetMessageTimer(player);
-							FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-							FrameMan:SetScreenText("Looks like a cave-in happened down here.  Dig through that sand, there might be something under it.", self:ScreenOfPlayer(player), 0, 7500, true);
+							FrameMan:ClearScreenText(screen);
+							FrameMan:SetScreenText("Looks like a cave-in happened down here.  Dig through that sand, there might be something under it.", screen, 0, 7500, true);
 							self.sacDestroyed = true;
 						end
 
 						if MovableMan:IsActor(self:GetControlledActor(player)) then
 							if self.pitfallArea:IsInside(self:GetControlledActor(player).Pos) and self.passedPitfall == false then
 								self:ResetMessageTimer(player);
-								FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-								FrameMan:SetScreenText("What the...?  It's some kind of ancient bunker?  There seems to be a control panel inside, go see what's on it...", self:ScreenOfPlayer(player), 0, 7500, true);
+								FrameMan:ClearScreenText(screen);
+								FrameMan:SetScreenText("What the...?  It's some kind of ancient bunker?  There seems to be a control panel inside, go see what's on it...", screen, 0, 7500, true);
 								AudioMan:ClearMusicQueue();
 								self.passedPitfall = true;
 
@@ -345,7 +346,7 @@ function DoainarMission:UpdateActivity()
 			local textTime = 5000;
 			for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 				if self:PlayerActive(player) and self:PlayerHuman(player) then
-					FrameMan:SetScreenText("These are cartesian coordinates...  Where could they possibly lead to?", self:ScreenOfPlayer(player), 0, textTime, true);
+					FrameMan:SetScreenText("These are cartesian coordinates...  Where could they possibly lead to?", screen, 0, textTime, true);
 				end
 			end
 			self.WinnerTeam = self.PlayerTeam;

--- a/Data/Missions.rte/Activities/DummyAssault.lua
+++ b/Data/Missions.rte/Activities/DummyAssault.lua
@@ -99,8 +99,9 @@ function DummyAssault:EndActivity()
 	if self.humanTeam == self.WinnerTeam then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
-				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-				FrameMan:SetScreenText("Congratulations, you've destroyed the enemy base!", self:ScreenOfPlayer(player), 0, -1, false);
+				local screen = self:ScreenOfPlayer(player);
+				FrameMan:ClearScreenText(screen);
+				FrameMan:SetScreenText("Congratulations, you've destroyed the enemy base!", screen, 0, -1, false);
 			end
 		end
 	end

--- a/Data/Missions.rte/Activities/Maginot.lua
+++ b/Data/Missions.rte/Activities/Maginot.lua
@@ -194,11 +194,12 @@ function MaginotMission:DoGameOverCheck()
 				self:GetBanner(GUIBanner.RED, player):ClearText();
 
 				if not self.GameOverTimer:IsPastSimMS(self.GameOverPeriod) then
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
 					if self.brainDead[player] then
-						FrameMan:SetScreenText("You may have died, but your fellow brains lived to fight another day. Rest assured, you will be avenged!", self:ScreenOfPlayer(player), 0, 1, false);
+						FrameMan:SetScreenText("You may have died, but your fellow brains lived to fight another day. Rest assured, you will be avenged!", screen, 0, 1, false);
 					else
-						FrameMan:SetScreenText("Good job, you lived to fight another day. We've located the enemy fortress and are planning an assault on it!", self:ScreenOfPlayer(player), 0, 1, false);
+						FrameMan:SetScreenText("Good job, you lived to fight another day. We've located the enemy fortress and are planning an assault on it!", screen, 0, 1, false);
 					end
 				else
 					ActivityMan:EndActivity();
@@ -246,25 +247,26 @@ function MaginotMission:UpdateScreenText()
 	if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
-				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+				local screen = self:ScreenOfPlayer(player);
+				FrameMan:ClearScreenText(screen);
 				if self.currentFightStage == self.fightStage.beginFight then
 					if self:GetTeamFunds(self.defenderTeam) == 0 then
-						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nYou'll have to make do with the forces you have on site. Good luck!", self:ScreenOfPlayer(player), 0, 1, false);
+						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nYou'll have to make do with the forces you have on site. Good luck!", screen, 0, 1, false);
 					else
-						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nPrepare while you can, they'll be here soon!", self:ScreenOfPlayer(player), 0, 1, false);
+						FrameMan:SetScreenText("Sensors show enemy dropship signatures en route to the West entrance.\nPrepare while you can, they'll be here soon!", screen, 0, 1, false);
 					end
 				elseif self.currentFightStage == self.fightStage.defendLeft then
-					FrameMan:SetScreenText("The onslaught has begun. Hold the line!", self:ScreenOfPlayer(player), 1500, 1, true);
+					FrameMan:SetScreenText("The onslaught has begun. Hold the line!", screen, 1500, 1, true);
 				elseif self.currentFightStage == self.fightStage.defendRight then
-					FrameMan:SetScreenText("ALERT: A ground attack force is moving on the Eastern entrance!", self:ScreenOfPlayer(player), 1500, 1, true);
+					FrameMan:SetScreenText("ALERT: A ground attack force is moving on the Eastern entrance!", screen, 1500, 1, true);
 				elseif self.currentFightStage == self.fightStage.evacuateBrain then
 					if self.PlayerCount == 1 then
-						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brain has been loaded onto a bot, get to the LZ and evacuate.", self:ScreenOfPlayer(player), 0, 1, true);
+						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brain has been loaded onto a bot, get to the LZ and evacuate.", screen, 0, 1, true);
 					else
-						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brains have been loaded onto bots, get as many of them as possible to the LZ and evacuate.", self:ScreenOfPlayer(player), 0, 1, true);
+						FrameMan:SetScreenText("The enemy force is too powerful, abandon the bunker immediately!\nYour brains have been loaded onto bots, get as many of them as possible to the LZ and evacuate.", screen, 0, 1, true);
 					end
 				elseif self.currentFightStage == self.fightStage.enterEvacuationRocket then
-					FrameMan:SetScreenText("The evacuation rocket is coming in hot, get to the LZ!", self:ScreenOfPlayer(player), 1500, 1, true);
+					FrameMan:SetScreenText("The evacuation rocket is coming in hot, get to the LZ!", screen, 1500, 1, true);
 				end
 			end
 		end

--- a/Data/Missions.rte/Activities/SignalHunt.lua
+++ b/Data/Missions.rte/Activities/SignalHunt.lua
@@ -475,8 +475,9 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 				if brain and self.currentFightStage > self.fightStage.beginFight and (not self.actorHoldingControlChip or self.actorHoldingControlChip.UniqueID ~= brain.UniqueID) and (not self.evacuationRocket or self.evacuationRocket.UniqueID ~= brain.UniqueID) then
 					self:AddObjectivePoint("Protect!", brain.AboveHUDPos, self.humanTeam, GameActivity.ARROWDOWN);
 				elseif not brain then
-					FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-					FrameMan:SetScreenText("Your brain has been lost!", self:ScreenOfPlayer(player), 333, -1, false);
+					local screen = self:ScreenOfPlayer(player);
+					FrameMan:ClearScreenText(screen);
+					FrameMan:SetScreenText("Your brain has been lost!", screen, 333, -1, false);
 				end
 			end
 		end
@@ -485,8 +486,9 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-						FrameMan:SetScreenText("Contractor, we at Alchiral appreciate your cooperation and confidentiality on this assignment.\nPlease enter the cave to ascertain the source of the signal.", self:ScreenOfPlayer(player), 0, 1, false);
+						local screen = self:ScreenOfPlayer(player);
+						FrameMan:ClearScreenText(screen);
+						FrameMan:SetScreenText("Contractor, we at Alchiral appreciate your cooperation and confidentiality on this assignment.\nPlease enter the cave to ascertain the source of the signal.", screen, 0, 1, false);
 					end
 				end
 			else
@@ -501,8 +503,9 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-						FrameMan:SetScreenText("Contractor, these cloning tubes are not your primary target.\nYou may destroy them if they are obstructing your progress, but your task is to find the source of the signal.\nProceed farther into the cave.", self:ScreenOfPlayer(player), 0, 1, false);
+						local screen = self:ScreenOfPlayer(player);
+						FrameMan:ClearScreenText(screen);
+						FrameMan:SetScreenText("Contractor, these cloning tubes are not your primary target.\nYou may destroy them if they are obstructing your progress, but your task is to find the source of the signal.\nProceed farther into the cave.", screen, 0, 1, false);
 					end
 				end
 			else
@@ -512,8 +515,9 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-						FrameMan:SetScreenText("Contractor, the signal is coming from that case; there is a modified Alchiral Cloning Control Chip inside it.\nDestroy the case and retrieve our property, once the chip is outside we will send a rocket to evacuate it to orbit.", self:ScreenOfPlayer(player), 0, 1, false);
+						local screen = self:ScreenOfPlayer(player);
+						FrameMan:ClearScreenText(screen);
+						FrameMan:SetScreenText("Contractor, the signal is coming from that case; there is a modified Alchiral Cloning Control Chip inside it.\nDestroy the case and retrieve our property, once the chip is outside we will send a rocket to evacuate it to orbit.", screen, 0, 1, false);
 					end
 				end
 			end
@@ -522,8 +526,9 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 			if self.secretIndex == nil and not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 				for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 					if self:PlayerActive(player) and self:PlayerHuman(player) then
-						FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-						FrameMan:SetScreenText(self:GetTeamOfPlayer(player) == self.humanTeam and "Get To The Rocket!!!" or "Y O U R   W I S H   I S   O U R   C O M M A N D,   O   D R E A D   L O R D\nW E   S H A L L   S L A U G H T E R   E V E R Y O N E", self:ScreenOfPlayer(player), 0, 1, true);
+						local screen = self:ScreenOfPlayer(player);
+						FrameMan:ClearScreenText(screen);
+						FrameMan:SetScreenText(self:GetTeamOfPlayer(player) == self.humanTeam and "Get To The Rocket!!!" or "Y O U R   W I S H   I S   O U R   C O M M A N D,   O   D R E A D   L O R D\nW E   S H A L L   S L A U G H T E R   E V E R Y O N E", screen, 0, 1, true);
 					end
 				end
 			else
@@ -531,8 +536,9 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 					if not self.evacuationRocketSpawned and self.numberOfAmbushingCraft > 0 then
 						for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 							if self:PlayerActive(player) and self:PlayerHuman(player) then
-								FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-								FrameMan:SetScreenText("ALERT: Contractor, unknown hostiles are entering the area. They must not retrieve the Cloning Control Chip!", self:ScreenOfPlayer(player), 500, 1, true);
+								local screen = self:ScreenOfPlayer(player);
+								FrameMan:ClearScreenText(screen);
+								FrameMan:SetScreenText("ALERT: Contractor, unknown hostiles are entering the area. They must not retrieve the Cloning Control Chip!", screen, 500, 1, true);
 							end
 						end
 					end
@@ -554,19 +560,21 @@ function SignalHunt:UpdateScreenTextAndObjectiveArrows(humanActorCount)
 	elseif self.WinnerTeam == self.humanTeam and not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) then
-				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
+				local screen = self:ScreenOfPlayer(player);
+				FrameMan:ClearScreenText(screen);
 				local endText = "Contractor, thank you for your efficient work. Your agreed-upon fee has been deposited to your account.\nWe at Alchiral are pleased with your performance, and look forward to a productive relationship with you in future.";
 				if self.secretIndex == nil then
 					endText = self:GetTeamOfPlayer(player) == self.humanTeam and "You may not have the chip, but at least you made it out after that betrayal!" or "D R E A D   L O R D,   T H E Y   H A V E   E S C A P E D   A N D   W I L L\nB R I N G   R U I N   D O W N   U P O N   U S   B E F O R E   W E   A R E   P R E P A R E D";
 				end
-				FrameMan:SetScreenText(endText, self:ScreenOfPlayer(player), 0, 1, true);
+				FrameMan:SetScreenText(endText, screen, 0, 1, true);
 			end
 		end
 	elseif self.WinnerTeam == self.zombieTeam and not self.screenTextTimer:IsPastSimMS(self.screenTextTimeLimit) then
 		for player = Activity.PLAYER_1, Activity.MAXPLAYERCOUNT - 1 do
 			if self:PlayerActive(player) and self:PlayerHuman(player) and self:GetTeamOfPlayer(player) == self.zombieTeam then
-				FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
-				FrameMan:SetScreenText("A    G R A N D    V I C T O R Y ,   Y O U R    H O R D E    S H A L L    G R O W    A N D    C O N Q U E R    T H I S    P L A N E T", self:ScreenOfPlayer(player), 0, 1, true);
+				local screen = self:ScreenOfPlayer(player);
+				FrameMan:ClearScreenText(screen);
+				FrameMan:SetScreenText("A    G R A N D    V I C T O R Y ,   Y O U R    H O R D E    S H A L L    G R O W    A N D    C O N Q U E R    T H I S    P L A N E T", screen, 0, 1, true);
 			end
 		end
 	end

--- a/Source/Managers/CameraMan.cpp
+++ b/Source/Managers/CameraMan.cpp
@@ -64,15 +64,17 @@ void CameraMan::SetScroll(const Vector& center, int screenId) {
 }
 
 Vector CameraMan::GetScrollTarget(int screenId) const {
-	if (screenId < 0 || screenId >= c_MaxScreenCount)
+	if (screenId < 0 || screenId >= c_MaxScreenCount) {
 		// Would it be preferable to just set screenId to 0?
 		return Vector();
+	}
 	return g_NetworkClient.IsConnectedAndRegistered() ? g_NetworkClient.GetFrameTarget() : m_Screens[screenId].ScrollTarget;
 }
 
 void CameraMan::SetScrollTarget(const Vector& targetCenter, float speed, int screenId) {
-	if (screenId < 0 || screenId >= c_MaxScreenCount)
+	if (screenId < 0 || screenId >= c_MaxScreenCount) {
 		return;
+	}
 
 	Screen& screen = m_Screens[screenId];
 

--- a/Source/Managers/CameraMan.cpp
+++ b/Source/Managers/CameraMan.cpp
@@ -64,10 +64,16 @@ void CameraMan::SetScroll(const Vector& center, int screenId) {
 }
 
 Vector CameraMan::GetScrollTarget(int screenId) const {
+	if (screenId < 0 || screenId >= c_MaxScreenCount)
+		// Would it be preferable to just set screenId to 0?
+		return Vector();
 	return g_NetworkClient.IsConnectedAndRegistered() ? g_NetworkClient.GetFrameTarget() : m_Screens[screenId].ScrollTarget;
 }
 
 void CameraMan::SetScrollTarget(const Vector& targetCenter, float speed, int screenId) {
+	if (screenId < 0 || screenId >= c_MaxScreenCount)
+		return;
+
 	Screen& screen = m_Screens[screenId];
 
 	// See if it would make sense to automatically wrap.


### PR DESCRIPTION
`CameraMan:GetScrollTarget()` and `CameraMan:SetScrollTarget()` both take a screen index but were often being passed player indices. I've hopefully caught and fixed all such instances. In addition, when `Activity:ScreenOfPlayer()` was being called multiple times in a row, I stored the result of a single call and replaced the multiple calls with that local variable.

Lastly, when I changed Decision Day to use each player's brain position instead of always using Player 1's, I accidentally wrote `pos` instead of `Pos`, so the first argument would've always been `nil`.