### PR TITLE
fix invalid link to Data directory & remove link to Credits.txt

### DIFF
--- a/Resources/cccp.sh
+++ b/Resources/cccp.sh
@@ -5,7 +5,7 @@ link_base_files() {
         exit 1
     fi
 
-    ln -s "${base_data_path}"/*.rte "${base_data_path}/Credits.txt" $tmp_dir
+	ln -s "${base_data_path}"/Data "$tmp_dir"
 }
 
 link_user_files() {

--- a/Resources/cccp.sh
+++ b/Resources/cccp.sh
@@ -5,12 +5,12 @@ link_base_files() {
         exit 1
     fi
 
-	ln -s "${base_data_path}"/Data "$tmp_dir"
+    ln -s "${base_data_path}"/Data "$tmp_dir"
 }
 
 link_user_files() {
-    local user_files=("LogConsole.txt" "LogLoading.txt" "LogLoadingWarning.txt" "AbortScreen.bmp" "AbortScreen.png" "Settings.ini")
-    local user_directories=("Metagames.rte" "Scenes.rte" "_ScreenShots")
+    local user_files=("LogConsole.txt" "LogLoading.txt" "LogLoadingWarning.txt" "AbortLog.txt" "AbortScreen.bmp" "AbortScreen.png")
+    local user_directories=("Mods" "Userdata" "ScreenShots")
 
     if ! [[ -d "${user_data}" ]]; then
         mkdir -p "${user_data}"
@@ -19,16 +19,6 @@ link_user_files() {
     for file in $user_files; do
         ln -s "${user_data}/$file" $tmp_dir
     done
-
-    if ! [[ -d "${user_data}/Metagames.rte" ]]; then
-        mkdir -p "${user_data}/Metagames.rte"
-        echo -e "DataModule\n\tModuleName = Metagame Saves" > "${user_data}/Metagames.rte/Index.ini"
-    fi
-
-    if ! [[ -d "${user_data}/Scenes.rte" ]]; then
-        mkdir -p "${user_data}/Scenes.rte"
-        echo -e "DataModule\n\tModuleName = Saves" > "${user_data}/Scenes.rte/Index.ini"
-    fi
 
     for directory in ${user_directories[@]}; do
         if ! [[ -d "${user_data}/${directory}" ]]; then
@@ -50,8 +40,6 @@ link_base_files
 link_user_files
 
 cd "${tmp_dir}"
-
-export CCCP_SETTINGSPATH="Settings.ini"
 
 "@EXEPATH@/@EXENAME@" $@
 


### PR DESCRIPTION
System:
```
OS: ALT Regular Sisyphus x86_64
Host: 82TT Lenovo V15 G3 IAP
Kernel: 6.6.25-un-def-alt1
DE: GNOME 46.0
```

Problem:
![Screenshot from 2024-04-19 18-53-12](https://github.com/cortex-command-community/Cortex-Command-Community-Project/assets/76654183/d5b48cf8-b698-44ad-aebc-a73a5779c40f)

Reason: 
Invalid symlink

*/tmp/CCCP.**
```
'*.rte' -> '/usr/share/CortexCommand/*.rte'
```

Solve:
Link must be called "Data"

*/tmp/CCCP.**
```
Data -> /usr/share/CortexCommand/Data
```
