### PR TITLE
Add Slow-Mo Buy Menu global script

### DIFF
--- a/Data/Base.rte/Scripts/Global/BuyMenuSlowMo.lua
+++ b/Data/Base.rte/Scripts/Global/BuyMenuSlowMo.lua
@@ -1,0 +1,39 @@
+function BuyMenuSlowMoScript:StartScript()
+	self.SlowMo = false;
+	self.Change = false;
+	self.originalTimeScale = TimerMan.TimeScale
+	self.originalDeltaTimeSecs = TimerMan.DeltaTimeSecs + 0
+end
+
+function BuyMenuSlowMoScript:UpdateScript()
+	local activity = ActivityMan:GetActivity();
+	if activity then
+		activity = ToGameActivity(activity);
+
+		-- Check if the buy menu is open
+		if activity:IsBuyGUIVisible(-1) then
+			if not self.SlowMo then
+				self.SlowMo = true;
+				self.Change = true;
+			end
+		else
+			if self.SlowMo then
+				self.SlowMo = false;
+				self.Change = true;
+			end
+		end
+	end
+
+	if self.Change then
+		if self.SlowMo then
+			-- Slow down time
+			TimerMan.DeltaTimeSecs = self.originalDeltaTimeSecs * 0.05
+			TimerMan.TimeScale = 0.1
+		else
+			-- Return time to normal
+			TimerMan.DeltaTimeSecs = self.originalDeltaTimeSecs
+			TimerMan.TimeScale = self.originalTimeScale
+		end
+		self.Change = false;
+	end
+end

--- a/Data/Base.rte/Scripts/GlobalScripts.ini
+++ b/Data/Base.rte/Scripts/GlobalScripts.ini
@@ -181,3 +181,10 @@ AddGlobalScript = GlobalScript
 	ScriptPath = Base.rte/Scripts/Global/Autosave.lua
 	LuaClassName = AutosaveScript
 	LateUpdate = 1
+
+
+AddGlobalScript = GlobalScript
+	PresetName = Buy Menu Slow-Motion
+	Description = Turns the game to slow-motion when you enter the Buy Menu.
+	ScriptPath = Base.rte/Scripts/Global/BuyMenuSlowMo.lua
+	LuaClassName = BuyMenuSlowMoScript

--- a/Source/Lua/LuaBindingsActivities.cpp
+++ b/Source/Lua/LuaBindingsActivities.cpp
@@ -132,6 +132,7 @@ LuaBindingRegisterFunctionDefinitionForType(ActivityLuaBindings, GameActivity) {
 	    .def("GetLandingZone", &GameActivity::GetLandingZone)
 	    .def("SetActorSelectCursor", &GameActivity::SetActorSelectCursor)
 	    .def("GetBuyGUI", &GameActivity::GetBuyGUI)
+	    .def("IsBuyGUIVisible", &GameActivity::IsBuyGUIVisible)
 	    .def("GetEditorGUI", &GameActivity::GetEditorGUI)
 	    .def("LockControlledActor", &GameActivity::LockControlledActor)
 	    .def("OtherTeam", &GameActivity::OtherTeam)


### PR DESCRIPTION
Added a new global script to Base.rte that slows down the game to 1/10th speed when the Buy Menu is open. Uses the current method of slow-motion that manually changes DeltaTime and TimeScale, but it seems to work pretty well. AFAIK there is no way to pause the simulation completely from Lua as of right now (setting the TimeScale to 0 causes all sorts of errors).

This involved opening up the IsBuyGUIVisible function to be able to access it from Lua in ActivityMan.