### PR TITLE
Linux build LuaJIT from external sources

### DIFF
--- a/external/include/meson.build
+++ b/external/include/meson.build
@@ -6,8 +6,6 @@ external_inc_dirs = [include_directories('boost_1_75',
                                          'thread-pool-3.5.0/include',
                                          'hopscotch-map-2.3.1/include',)]
 if host_machine.system() in ['linux', 'darwin']
-  luajit_proj = subproject('LuaJIT-2.1', default_options: ['header_only=true'])
-  external_inc_dirs += luajit_proj.get_variable('luajit_source_dir')
 endif
 if host_machine.system() == 'windows'
   external_inc_dirs += include_directories('LZ4-1.9.3/LZ4',)

--- a/external/sources/LuaJIT-2.1/meson.build
+++ b/external/sources/LuaJIT-2.1/meson.build
@@ -1,5 +1,6 @@
 # Meson files from github.com/franko/luajit
 project('luajit', 'c', version : '2.0.5', default_options : ['c_winlibs='])
+
 pkg = import('pkgconfig')
 
 cc = meson.get_compiler('c')
@@ -7,14 +8,19 @@ libm = cc.find_library('m', required : false)
 libdl = cc.find_library('dl', required : false)
 luajit_dependencies = [libm, libdl]
 
+
 luajit_source_dir = include_directories('src')
 luajit_abiver = '51'
+
+if not meson.can_run_host_binaries()
+    warning('Can\'t properly build in cross environment, using system library instead!')
+else
 
 dynasm = files('dynasm/dynasm.lua')
 
 subdir('src')
 
-if not get_option('use_prebuilt_libraries') or host_machine.system() in ['darwin', 'linux']
+if not get_option('use_prebuilt_libraries') or host_machine.system() in ['linux', 'darwin']
     libluajit = library(lj_libname, ljlib_sources + ljcore_sources + buildvm_headers,
         include_directories: luajit_source_dir,
         c_args: lj_defines,
@@ -40,3 +46,4 @@ luajit_dep = declare_dependency(
 )
 
 meson.override_dependency('luajit', luajit_dep)
+endif

--- a/external/sources/LuaJIT-2.1/meson.build
+++ b/external/sources/LuaJIT-2.1/meson.build
@@ -1,8 +1,5 @@
 # Meson files from github.com/franko/luajit
 project('luajit', 'c', version : '2.0.5', default_options : ['c_winlibs='])
-if get_option('header_only')
-  luajit_source_dir = include_directories('src')
-else
 pkg = import('pkgconfig')
 
 cc = meson.get_compiler('c')
@@ -43,4 +40,3 @@ luajit_dep = declare_dependency(
 )
 
 meson.override_dependency('luajit', luajit_dep)
-endif

--- a/external/sources/LuaJIT-2.1/meson_options.txt
+++ b/external/sources/LuaJIT-2.1/meson_options.txt
@@ -1,3 +1,3 @@
-
+option('portable', type : 'boolean', value : false, description: 'portable install in a single directory')
+option('app', type : 'boolean', value : true, description: 'Build the luajit executable')
 option('use_prebuilt_libraries', type: 'boolean', value: true, yield: true, description: 'On windows use the prebuilt libraries')
-option('header_only', type: 'boolean', value: false, description: 'Only expose the header files')

--- a/external/sources/LuaJIT-2.1/src/host/meson.build
+++ b/external/sources/LuaJIT-2.1/src/host/meson.build
@@ -1,4 +1,3 @@
-# Meson files from github.com/franko/luajit
 minilua = executable('minilua', 'minilua.c', dependencies: libm, install: false, native: true)
 
 lj_arch_run = cc.run(lj_arch_test_source)
@@ -28,7 +27,7 @@ buildvm_arch_h = custom_target('buildvm_arch.h',
     command : dasm_args,
 )
 
-buildvm_sources = files(['buildvm.c', 'buildvm_asm.c', 'buildvm_peobj.c', 'buildvm_lib.c', 'buildvm_fold.c'])
+buildvm_sources = files('buildvm.c', 'buildvm_asm.c', 'buildvm_peobj.c', 'buildvm_lib.c', 'buildvm_fold.c')
 buildvm_sources += buildvm_arch_h
 
 buildvm = executable('buildvm',

--- a/external/sources/LuaJIT-2.1/src/jit/meson.build
+++ b/external/sources/LuaJIT-2.1/src/jit/meson.build
@@ -1,2 +1,5 @@
-# Meson files from github.com/franko/luajit
 jitlib_files = files('bc.lua', 'v.lua', 'dump.lua', 'dis_x86.lua', 'dis_x64.lua', 'dis_arm.lua', 'dis_ppc.lua', 'dis_mips.lua', 'dis_mipsel.lua', 'bcsave.lua')
+
+if get_option('app')
+  install_data(jitlib_files, install_dir: jitlib_install_dir)
+endif

--- a/external/sources/LuaJIT-2.1/src/lj_arch_test.c
+++ b/external/sources/LuaJIT-2.1/src/lj_arch_test.c
@@ -26,7 +26,7 @@ static void add_def(const char *args[], int *args_n, const char *def) {
 }
 
 int main() {
-const char *lj_arch, *lj_os, *dasm_arch;
+const char *lj_arch, *dasm_arch;
 const char *arch_defs[16];
 int arch_defs_n = 0;
 const char *x_arch_option = NULL;
@@ -37,6 +37,8 @@ lj_arch = "x64";
 lj_arch = "x86";
 #elif LJ_TARGET_ARM
 lj_arch = "arm";
+#elif LJ_TARGET_ARM64
+lj_arch = "arm64";
 #elif LJ_TARGET_PPC
 lj_arch = "ppc";
 #elif LJ_TARGET_PPCSPE
@@ -59,29 +61,8 @@ if (x_arch_option) {
     arch_defs[arch_defs_n++] = x_arch_option;
 }
 
-#if LUAJIT_OS == LUAJIT_OS_OTHER
-lj_os = "OTHER";
-#elif LUAJIT_OS == LUAJIT_OS_WINDOWS
-lj_os = "WINDOWS";
-#elif LUAJIT_OS == LUAJIT_OS_LINUX
-lj_os = "LINUX";
-#elif LUAJIT_OS == LUAJIT_OS_OSX
-lj_os = "OSX";
-#elif LUAJIT_OS == LUAJIT_OS_BSD
-lj_os = "BSD";
-#elif LUAJIT_OS == LUAJIT_OS_POSIX
-lj_os = "POSIX";
-#else
-fprintf(stderr, "Unsupported OS\n");
-exit(1);
-#endif
-
-char luajit_os_def[128];
-sprintf(luajit_os_def, "-DLUAJIT_OS=LUAJIT_OS_%s", lj_os);
-arch_defs[arch_defs_n++] = luajit_os_def;
-
-#if defined(LJ_TARGET_X64) && defined(LUAJIT_DISABLE_GC64)
-dasm_arch = "x86";
+#ifdef LJ_TARGET_X64
+dasm_arch = "x64";
 #else
 dasm_arch = lj_arch;
 #endif
@@ -89,6 +70,11 @@ dasm_arch = lj_arch;
 const char *dasm[32];
 int dasm_n = 0;
 
+#ifdef LJ_LE
+add_def(dasm, &dasm_n, "ENDIAN_LE");
+#else
+add_def(dasm, &dasm_n, "ENDIAN_BE");
+#endif
 #if LJ_ARCH_BITS == 64
 add_def(dasm, &dasm_n, "P64");
 #endif

--- a/external/sources/LuaJIT-2.1/src/meson.build
+++ b/external/sources/LuaJIT-2.1/src/meson.build
@@ -1,87 +1,32 @@
-# Meson files from github.com/franko/luajit
-
-
 lj_arch_test_source = files('lj_arch_test.c')
 
-jitlib_install_dir = 'share' / ( 'luajit-' + meson.project_version() ) / 'jit'
+if get_option('portable')
+    jitlib_install_dir = get_option('bindir') / 'lua' / 'jit'
+else
+    jitlib_install_dir = 'share' / ( 'luajit-' + meson.project_version() ) / 'jit'
+endif
 
 subdir('host')
 
 ljlib_sources = files(
-'lib_aux.c',
-'lib_base.c',
-'lib_bit.c',
-'lib_buffer.c',
-'lib_debug.c',
-'lib_ffi.c',
-'lib_init.c',
-'lib_io.c',
-'lib_jit.c',
-'lib_math.c',
-'lib_os.c',
-'lib_package.c',
-'lib_string.c',
-'lib_table.c',
-)
-
+    'lib_base.c', 'lib_math.c', 'lib_bit.c', 'lib_string.c', 'lib_table.c',
+    'lib_io.c', 'lib_os.c', 'lib_package.c', 'lib_debug.c', 'lib_jit.c', 'lib_ffi.c',
+    'lib_buffer.c')
 ljcore_sources = files(
-'lj_alloc.c',
-'lj_api.c',
-'lj_asm.c',
-'lj_assert.c',
-'lj_bc.c',
-'lj_bcread.c',
-'lj_bcwrite.c',
-'lj_buf.c',
-'lj_carith.c',
-'lj_ccall.c',
-'lj_ccallback.c',
-'lj_cconv.c',
-'lj_cdata.c',
-'lj_char.c',
-'lj_clib.c',
-'lj_cparse.c',
-'lj_crecord.c',
-'lj_ctype.c',
-'lj_debug.c',
-'lj_dispatch.c',
-'lj_err.c',
-'lj_ffrecord.c',
-'lj_func.c',
-'lj_gc.c',
-'lj_gdbjit.c',
-'lj_ir.c',
-'lj_lex.c',
-'lj_lib.c',
-'lj_load.c',
-'lj_mcode.c',
-'lj_meta.c',
-'lj_obj.c',
-'lj_opt_dce.c',
-'lj_opt_fold.c',
-'lj_opt_loop.c',
-'lj_opt_mem.c',
-'lj_opt_narrow.c',
-'lj_opt_sink.c',
-'lj_opt_split.c',
-'lj_parse.c',
-'lj_prng.c',
-'lj_profile.c',
-'lj_record.c',
-'lj_serialize.c',
-'lj_snap.c',
-'lj_state.c',
-'lj_str.c',
-'lj_strfmt.c',
-'lj_strfmt_num.c',
-'lj_strscan.c',
-'lj_tab.c',
-'lj_trace.c',
-'lj_udata.c',
-'lj_vmevent.c',
-'lj_vmmath.c',
-)
-
+    'lj_assert.c', 'lj_gc.c', 'lj_err.c', 'lj_char.c', 'lj_bc.c', 'lj_obj.c', 'lj_buf.c',
+    'lj_str.c', 'lj_tab.c', 'lj_func.c', 'lj_udata.c', 'lj_meta.c', 'lj_debug.c',
+    'lj_prng.c', 'lj_state.c', 'lj_dispatch.c', 'lj_vmevent.c', 'lj_vmmath.c',
+    'lj_strscan.c', 'lj_strfmt.c', 'lj_strfmt_num.c', 'lj_serialize.c',
+    'lj_api.c', 'lj_profile.c',
+    'lj_lex.c', 'lj_parse.c', 'lj_bcread.c', 'lj_bcwrite.c', 'lj_load.c',
+    'lj_ir.c', 'lj_opt_mem.c', 'lj_opt_fold.c', 'lj_opt_narrow.c',
+    'lj_opt_dce.c', 'lj_opt_loop.c', 'lj_opt_split.c', 'lj_opt_sink.c',
+    'lj_mcode.c', 'lj_snap.c', 'lj_record.c', 'lj_crecord.c', 'lj_ffrecord.c',
+    'lj_asm.c', 'lj_trace.c', 'lj_gdbjit.c',
+    'lj_ctype.c', 'lj_cdata.c', 'lj_cconv.c', 'lj_ccall.c', 'lj_ccallback.c',
+    'lj_carith.c', 'lj_clib.c', 'lj_cparse.c',
+    'lj_lib.c', 'lj_alloc.c', 'lib_aux.c',
+    'lib_init.c')
 ljmain_sources = files('luajit.c')
 
 buildvm_commands = [
@@ -101,7 +46,18 @@ lj_defines = [
 ]
 
 if host_machine.system() == 'darwin'
-    lj_defines += '-mmacosx-version-min=10.11'
+    lj_defines += '-DLUAJIT_UNWIND_EXTERNAL'
+elif host_machine.system() != 'windows'
+    if 'NO_UNWIND' not in dasm_args
+        test_unwind = run_command('test-unwind.sh', ' '.join(cc.cmd_array()), check : false)
+        if test_unwind.stdout().strip() == 'E'
+            lj_defines += '-DLUAJIT_UNWIND_EXTERNAL'
+        endif
+    endif
+endif
+
+if get_option('portable')
+    lj_defines += '-DLUAJIT_PORTABLE_INSTALL'
 endif
 
 lj_linkargs = []
@@ -125,7 +81,6 @@ elif host_machine.system() == 'darwin'
     )
     lj_libname = 'luajit'
     lj_libprefix = 'lib'
-    lj_linkargs += ['-pagezero_size', '10000', '-image_base', '100000000']
 else
     ljcore_sources += custom_target('lj_vm.s',
         input : [],
@@ -149,7 +104,7 @@ vmdef = custom_target('vmdef.lua',
     input : ljlib_sources,
     output : 'vmdef.lua',
     build_by_default : false,
-    install: true,
+    install: false,
     install_dir: jitlib_install_dir,
     command : [buildvm, '-m', 'vmdef', '-o', '@OUTPUT@', '@INPUT@']
 )

--- a/external/sources/LuaJIT-2.1/src/test-unwind.sh
+++ b/external/sources/LuaJIT-2.1/src/test-unwind.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+TEST_CC="$1"
+
+cat << EOF > tmpunwind.c
+extern void b(void);
+
+int a(void) {
+    b();
+    return 0;
+}
+EOF
+
+$TEST_CC -c -x c tmpunwind.c -o tmpunwind.o && {
+  grep -qa -e eh_frame -e __unwind_info tmpunwind.o ||
+  grep -qU -e eh_frame -e __unwind_info tmpunwind.o
+} && echo E
+
+rm -f tmpunwind.c tmpunwind.o

--- a/meson.build
+++ b/meson.build
@@ -218,7 +218,7 @@ elif host_machine.system() == 'windows'
   libpng_dep = dependency('libpng')
   # Windows Libraries
   opengl = compiler.find_library('opengl32')
-  deps += [sdl2_dep, luajit_dep, zlib_dep, minizip_dep, libpng_dep, opengl]
+  deps += [sdl2_dep, zlib_dep, minizip_dep, libpng_dep, opengl]
 endif
 
 
@@ -230,8 +230,9 @@ boost_dep = declare_dependency(include_directories: include_directories('externa
 meson.override_dependency('boost-175', boost_dep)
 install_rpath = prefix/get_option('fmod_dir')
 allegro_proj = subproject('allegro 4.4.3.1-custom')
-luajit = subproject('LuaJIT-2.1')
+luajit_proj = subproject('LuaJIT-2.1')
 luajit_dep = dependency('luajit')
+external_inc_dirs += luajit_proj.get_variable('luajit_source_dir')
 allegro_dep = dependency('allegro')
 loadpng_dep = dependency('loadpng')
 luabind_proj = subproject('luabind-0.7.1')

--- a/meson.build
+++ b/meson.build
@@ -195,7 +195,6 @@ if host_machine.system() in ['linux','darwin']
     dependency(['sdl2']),
     dependency('flac'),
     dependency('minizip'),
-    dependency('luajit'),
     dependency('threads'),
     dependency('liblz4'),
     dependency('libpng'),
@@ -211,8 +210,6 @@ if host_machine.system() in ['linux','darwin']
 elif host_machine.system() == 'windows'
   sdl2 = subproject('SDL2-2.26.3')
   sdl2_dep = dependency('sdl2')
-  luajit = subproject('LuaJIT-2.1')
-  luajit_dep = dependency('luajit')
   zlib = subproject('zlib-ng-2.1.3')
   zlib_dep = dependency('zlib')
   minizip = subproject('minizip-ng-4.0.0')
@@ -233,6 +230,8 @@ boost_dep = declare_dependency(include_directories: include_directories('externa
 meson.override_dependency('boost-175', boost_dep)
 install_rpath = prefix/get_option('fmod_dir')
 allegro_proj = subproject('allegro 4.4.3.1-custom')
+luajit = subproject('LuaJIT-2.1')
+luajit_dep = dependency('luajit')
 allegro_dep = dependency('allegro')
 loadpng_dep = dependency('loadpng')
 luabind_proj = subproject('luabind-0.7.1')
@@ -241,7 +240,7 @@ raknet_proj = subproject('RakNet')
 raknet_dep = dependency('RakNet')
 tracy_proj = subproject('tracy')
 tracy_dep = dependency('tracy')
-deps += [allegro_dep, loadpng_dep, raknet_dep, boost_dep, tracy_dep]
+deps += [allegro_dep, luajit_dep, loadpng_dep, raknet_dep, boost_dep, tracy_dep]
 
 #### Sources Setup ####
 source_inc_dirs = []

--- a/meson_osxcross.txt
+++ b/meson_osxcross.txt
@@ -1,0 +1,15 @@
+[constants]
+arch = 'x86_64-apple-darwin20.2'
+[binaries]
+c = ['ccache', arch + '-gcc']
+cpp = ['ccache', arch + '-g++']
+strip = arch + '-strip'
+pkg-config = arch  + '-pkg-config'
+ranlib = arch + '-gcc-ranlib'
+ar = arch + '-gcc-ar'
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'


### PR DESCRIPTION
- Updated LuaJIT meson build files to allow building on linux (should also build on native macos).
- Macos Cross build continues to use prebuilt libs, since the build doesn't work in the cross chain (currently requires running some code on the target machine) 