### PR TITLE
allow/enable Bitwise operations library for scripts.

### DIFF
--- a/Source/Managers/LuaMan.cpp
+++ b/Source/Managers/LuaMan.cpp
@@ -44,6 +44,7 @@ void LuaStateWrapper::Initialize() {
 	    {LUA_STRLIBNAME, luaopen_string},
 	    {LUA_MATHLIBNAME, luaopen_math},
 	    {LUA_DBLIBNAME, luaopen_debug},
+	    {LUA_BITLIBNAME, luaopen_bit},
 	    {LUA_JITLIBNAME, luaopen_jit},
 	    {NULL, NULL} // End of array
 	};


### PR DESCRIPTION
Makes it so that scripts are allowed to access and use the Bitwise operations module (also known as BitOp) that is bundled with LuaJIT.

See here for info about the functions provided by this: https://bitop.luajit.org/api.html