### PR TITLE
ci: ensure nightly builds fail loudly if unable to update previous tag

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Update tag pointing to the previous nightly release
         if: steps.check_nightly.outputs.release_exists
         run: |
-          curl -X PATCH \
+          curl --fail-with-body -X PATCH \
             -H "Authorization: Bearer ${{ secrets.WORKFLOW_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${{ env.PREV_TAG }} \


### PR DESCRIPTION
Does what it says on the tin

Add the `--fail-with-body` flag to the curl invocation that is supposed to update the old flag, so if the token is expired etc then it should fail the action. 