### PR TITLE
fix function lookup for chached scripts

### DIFF
--- a/Source/Managers/LuaMan.cpp
+++ b/Source/Managers/LuaMan.cpp
@@ -740,8 +740,10 @@ int LuaStateWrapper::RunScriptFileAndRetrieveFunctions(const std::string& filePa
 	auto cachedScript = m_ScriptCache.find(filePath);
 	if (!forceReload && cachedScript != m_ScriptCache.end()) {
 		for (auto& pair: cachedScript->second.functionNamesAndObjects) {
-			luabind::object* functionObjectCopyForStoring = new luabind::object(*pair.second->GetLuabindObject());
-			outFunctionNamesAndObjects.try_emplace(pair.first, new LuabindObjectWrapper(functionObjectCopyForStoring, filePath));
+			if (std::find(functionNamesToLookFor.begin(), functionNamesToLookFor.end(), pair.first) != functionNamesToLookFor.end()) {
+				luabind::object* functionObjectCopyForStoring = new luabind::object(*pair.second->GetLuabindObject());
+				outFunctionNamesAndObjects.try_emplace(pair.first, new LuabindObjectWrapper(functionObjectCopyForStoring, filePath));
+			}
 		}
 
 		return 0;


### PR DESCRIPTION
function lookup will now still check function names even when reading already cached scripts, so certain scripts that might be used by different object types can have functions unsupported by some of them without crashing the game