### PR TITLE
Check for valid pointer before calling CastSeeRays method.

### DIFF
--- a/Source/Managers/MovableMan.cpp
+++ b/Source/Managers/MovableMan.cpp
@@ -1371,7 +1371,7 @@ void MovableMan::Update() {
 		                                                                            [&](int start, int end) {
 			                                                                            ZoneScopedN("Actors See");
 			                                                                            for (int i = start; i < end; ++i) {
-				                                                                            m_Actors[i]->CastSeeRays();
+				                                                                            if (m_Actors[i]) m_Actors[i]->CastSeeRays();
 			                                                                            }
 		                                                                            });
 

--- a/Source/Managers/MovableMan.cpp
+++ b/Source/Managers/MovableMan.cpp
@@ -1371,7 +1371,11 @@ void MovableMan::Update() {
 		                                                                            [&](int start, int end) {
 			                                                                            ZoneScopedN("Actors See");
 			                                                                            for (int i = start; i < end; ++i) {
-				                                                                            if (m_Actors[i]) m_Actors[i]->CastSeeRays();
+													    // TODO - this null check really shouldn't be required. There's almost definitely an issue where the actor update can somehow fuck with this mid-update
+													    // this is VERY bad, and needs investigation!
+				                                                                            if (m_Actors[i]) { 
+														    m_Actors[i]->CastSeeRays();
+													    }
 			                                                                            }
 		                                                                            });
 


### PR DESCRIPTION
Mitigates #147.