### PR TITLE
Gibs and detached Attachables inherit rotational velocity from parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Almost all ctrl+* special inputs functionality (i.e restarting activity, world dumps, showing performance stats) are now mapped to right alt, to not interfere with default crouching inputs. The only exception is ctrl+arrow keys for changing console size.
 
-- Gibs now inherit velocity derived from the angular velocity of an MO. This only affects gibs with an offset, and is scaled by `InheritsVel`.
+- Gibs and Attachables detached due to gibbing now inherit velocity derived from the angular velocity of the parent MO. This only has an effect when the gib/attachable is offset, and gibs are further scaled by `InheritsVel`.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Almost all ctrl+* special inputs functionality (i.e restarting activity, world dumps, showing performance stats) are now mapped to right alt, to not interfere with default crouching inputs. The only exception is ctrl+arrow keys for changing console size.
 
-- Gibs and Attachables detached due to gibbing now inherit velocity derived from the angular velocity of the parent MO. This only has an effect when the gib/attachable is offset, and gibs are further scaled by `InheritsVel`.
+- Gibs and detached Attachables now inherit the parent's angular velocity, as well as velocity derived from the angular velocity of the parent MO and their offset from the parent's centre. On gibs, this is scaled by `InheritsVel`.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Almost all ctrl+* special inputs functionality (i.e restarting activity, world dumps, showing performance stats) are now mapped to right alt, to not interfere with default crouching inputs. The only exception is ctrl+arrow keys for changing console size.
 
+- Gibs now inherit velocity derived from the angular velocity of an MO. This only affects gibs with an offset, and is scaled by `InheritsVel`.
+
 </details>
 
 <details><summary><b>Fixed</b></summary>

--- a/Source/Entities/MOSRotating.cpp
+++ b/Source/Entities/MOSRotating.cpp
@@ -943,9 +943,11 @@ void MOSRotating::CreateGibsWhenGibbing(const Vector& impactImpulse, MovableObje
 				Vector gibVelocity(radius * scale + minVelocity, 0);
 				gibVelocity.RadRotate(randAngle + RandomNum(0.0F, spread) + static_cast<float>(i) * goldenAngle);
 
-				if (gibSettingsObject.InheritsVelocity() > 0 && !rotatedGibOffset.IsZero()) {
-					Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
-					gibVelocity += rotationalVelocity;
+				if (gibSettingsObject.InheritsVelocity() > 0) {
+					if (!rotatedGibOffset.IsZero()) {
+						Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
+						gibVelocity += rotationalVelocity;
+					}
 					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + m_AngularVel * gibSettingsObject.InheritsVelocity());
 				}
 
@@ -1006,9 +1008,11 @@ void MOSRotating::CreateGibsWhenGibbing(const Vector& impactImpulse, MovableObje
 					gibVelocity.RadRotate(gibSpread * RandomNormalNum());
 				}
 
-				if (gibSettingsObject.InheritsVelocity() > 0 && !rotatedGibOffset.IsZero()) {
-					Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
-					gibVelocity += rotationalVelocity;
+				if (gibSettingsObject.InheritsVelocity() > 0) {
+					if (!rotatedGibOffset.IsZero()) {
+						Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
+						gibVelocity += rotationalVelocity;
+					}
 					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + m_AngularVel * gibSettingsObject.InheritsVelocity());
 				}
 
@@ -1034,6 +1038,12 @@ void MOSRotating::RemoveAttachablesWhenGibbing(const Vector& impactImpulse, Mova
 		RTEAssert(attachable, "Broken Attachable when Gibbing!");
 
 		if (RandomNum() < attachable->GetGibWithParentChance() || attachable->GetGibWhenRemovedFromParent()) {
+			float attachableGibBlastStrength = (attachable->GetParentGibBlastStrengthMultiplier() * m_GibBlastStrength) / (1 + attachable->GetMass());
+			attachable->SetAngularVel((attachable->GetAngularVel() * 0.5F) + (attachable->GetAngularVel() * 0.5F * attachableGibBlastStrength * RandomNormalNum()));
+			Vector gibBlastVel = Vector(attachable->GetParentOffset()).SetMagnitude(attachableGibBlastStrength * 0.5F + (attachableGibBlastStrength * RandomNum()));
+			Vector rotationalVelocity = ((attachable->GetPos() - m_Pos).GetPerpendicular() * m_AngularVel) / c_PPM;
+			attachable->SetAngularVel(attachable->GetAngularVel() + m_AngularVel);
+			attachable->SetVel(m_Vel + gibBlastVel + rotationalVelocity); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
 			attachable->GibThis();
 			continue;
 		}
@@ -1042,7 +1052,9 @@ void MOSRotating::RemoveAttachablesWhenGibbing(const Vector& impactImpulse, Mova
 			float attachableGibBlastStrength = (attachable->GetParentGibBlastStrengthMultiplier() * m_GibBlastStrength) / (1 + attachable->GetMass());
 			attachable->SetAngularVel((attachable->GetAngularVel() * 0.5F) + (attachable->GetAngularVel() * 0.5F * attachableGibBlastStrength * RandomNormalNum()));
 			Vector gibBlastVel = Vector(attachable->GetParentOffset()).SetMagnitude(attachableGibBlastStrength * 0.5F + (attachableGibBlastStrength * RandomNum()));
-			attachable->SetVel(m_Vel + gibBlastVel); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
+			Vector rotationalVelocity = ((attachable->GetPos() - m_Pos).GetPerpendicular() * m_AngularVel) / c_PPM;
+			attachable->SetAngularVel(attachable->GetAngularVel() + m_AngularVel);
+			attachable->SetVel(m_Vel + gibBlastVel + rotationalVelocity); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
 
 			if (movableObjectToIgnore) {
 				attachable->SetWhichMOToNotHit(movableObjectToIgnore);

--- a/Source/Entities/MOSRotating.cpp
+++ b/Source/Entities/MOSRotating.cpp
@@ -944,11 +944,10 @@ void MOSRotating::CreateGibsWhenGibbing(const Vector& impactImpulse, MovableObje
 				gibVelocity.RadRotate(randAngle + RandomNum(0.0F, spread) + static_cast<float>(i) * goldenAngle);
 
 				if (gibSettingsObject.InheritsVelocity() > 0) {
-					if (!rotatedGibOffset.IsZero()) {
-						Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
-						gibVelocity += rotationalVelocity;
-					}
-					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + m_AngularVel * gibSettingsObject.InheritsVelocity());
+					Vector offsetFromRootParent = m_Pos - GetRootParent()->GetPos() + rotatedGibOffset;
+					Vector rotationalVelocity = (offsetFromRootParent.GetPerpendicular() * GetRootParent()->GetAngularVel() * gibSettingsObject.InheritsVelocity()) / c_PPM;
+					gibVelocity += rotationalVelocity;
+					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + GetRootParent()->GetAngularVel() * gibSettingsObject.InheritsVelocity());
 				}
 
 				if (lifetime != 0) {
@@ -1009,11 +1008,10 @@ void MOSRotating::CreateGibsWhenGibbing(const Vector& impactImpulse, MovableObje
 				}
 
 				if (gibSettingsObject.InheritsVelocity() > 0) {
-					if (!rotatedGibOffset.IsZero()) {
-						Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
-						gibVelocity += rotationalVelocity;
-					}
-					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + m_AngularVel * gibSettingsObject.InheritsVelocity());
+					Vector offsetFromRootParent = m_Pos - GetRootParent()->GetPos() + rotatedGibOffset;
+					Vector rotationalVelocity = (offsetFromRootParent.GetPerpendicular() * GetRootParent()->GetAngularVel() * gibSettingsObject.InheritsVelocity()) / c_PPM;
+					gibVelocity += rotationalVelocity;
+					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + GetRootParent()->GetAngularVel() * gibSettingsObject.InheritsVelocity());
 				}
 
 				gibParticleClone->SetVel(gibVelocity + ((m_PrevVel + m_Vel) / 2) * gibSettingsObject.InheritsVelocity());
@@ -1480,8 +1478,8 @@ Attachable* MOSRotating::RemoveAttachable(Attachable* attachable, bool addToMova
 	}
 	RTEAssert(attachable->IsAttachedTo(this), "Tried to remove Attachable " + attachable->GetPresetNameAndUniqueID() + " from presumed parent " + GetPresetNameAndUniqueID() + ", but it had a different parent (" + (attachable->GetParent() ? attachable->GetParent()->GetPresetNameAndUniqueID() : "ERROR") + "). This should never happen!");
 
-	Vector rotationalVelocity = ((attachable->GetPos() - m_Pos).GetPerpendicular() * m_AngularVel) / c_PPM;
-	attachable->SetAngularVel(attachable->GetAngularVel() + m_AngularVel);
+	Vector rotationalVelocity = ((attachable->GetPos() - GetRootParent()->GetPos()).GetPerpendicular() * GetRootParent()->GetAngularVel()) / c_PPM;
+	attachable->SetAngularVel(attachable->GetAngularVel() + GetRootParent()->GetAngularVel());
 	attachable->SetVel(attachable->GetVel() + rotationalVelocity); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
 
 	if (!m_Attachables.empty()) {

--- a/Source/Entities/MOSRotating.cpp
+++ b/Source/Entities/MOSRotating.cpp
@@ -1041,9 +1041,7 @@ void MOSRotating::RemoveAttachablesWhenGibbing(const Vector& impactImpulse, Mova
 			float attachableGibBlastStrength = (attachable->GetParentGibBlastStrengthMultiplier() * m_GibBlastStrength) / (1 + attachable->GetMass());
 			attachable->SetAngularVel((attachable->GetAngularVel() * 0.5F) + (attachable->GetAngularVel() * 0.5F * attachableGibBlastStrength * RandomNormalNum()));
 			Vector gibBlastVel = Vector(attachable->GetParentOffset()).SetMagnitude(attachableGibBlastStrength * 0.5F + (attachableGibBlastStrength * RandomNum()));
-			Vector rotationalVelocity = ((attachable->GetPos() - m_Pos).GetPerpendicular() * m_AngularVel) / c_PPM;
-			attachable->SetAngularVel(attachable->GetAngularVel() + m_AngularVel);
-			attachable->SetVel(m_Vel + gibBlastVel + rotationalVelocity); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
+			attachable->SetVel(attachable->GetVel() + gibBlastVel); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
 			attachable->GibThis();
 			continue;
 		}
@@ -1052,9 +1050,7 @@ void MOSRotating::RemoveAttachablesWhenGibbing(const Vector& impactImpulse, Mova
 			float attachableGibBlastStrength = (attachable->GetParentGibBlastStrengthMultiplier() * m_GibBlastStrength) / (1 + attachable->GetMass());
 			attachable->SetAngularVel((attachable->GetAngularVel() * 0.5F) + (attachable->GetAngularVel() * 0.5F * attachableGibBlastStrength * RandomNormalNum()));
 			Vector gibBlastVel = Vector(attachable->GetParentOffset()).SetMagnitude(attachableGibBlastStrength * 0.5F + (attachableGibBlastStrength * RandomNum()));
-			Vector rotationalVelocity = ((attachable->GetPos() - m_Pos).GetPerpendicular() * m_AngularVel) / c_PPM;
-			attachable->SetAngularVel(attachable->GetAngularVel() + m_AngularVel);
-			attachable->SetVel(m_Vel + gibBlastVel + rotationalVelocity); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
+			attachable->SetVel(attachable->GetVel() + gibBlastVel); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
 
 			if (movableObjectToIgnore) {
 				attachable->SetWhichMOToNotHit(movableObjectToIgnore);
@@ -1483,6 +1479,10 @@ Attachable* MOSRotating::RemoveAttachable(Attachable* attachable, bool addToMova
 		return attachable;
 	}
 	RTEAssert(attachable->IsAttachedTo(this), "Tried to remove Attachable " + attachable->GetPresetNameAndUniqueID() + " from presumed parent " + GetPresetNameAndUniqueID() + ", but it had a different parent (" + (attachable->GetParent() ? attachable->GetParent()->GetPresetNameAndUniqueID() : "ERROR") + "). This should never happen!");
+
+	Vector rotationalVelocity = ((attachable->GetPos() - m_Pos).GetPerpendicular() * m_AngularVel) / c_PPM;
+	attachable->SetAngularVel(attachable->GetAngularVel() + m_AngularVel);
+	attachable->SetVel(attachable->GetVel() + rotationalVelocity); // Attachables have already had their velocity updated by ApplyImpulses(), no need to add impactImpulse again
 
 	if (!m_Attachables.empty()) {
 		m_Attachables.remove(attachable);

--- a/Source/Entities/MOSRotating.cpp
+++ b/Source/Entities/MOSRotating.cpp
@@ -942,6 +942,13 @@ void MOSRotating::CreateGibsWhenGibbing(const Vector& impactImpulse, MovableObje
 				gibParticleClone->SetHFlipped(m_HFlipped);
 				Vector gibVelocity(radius * scale + minVelocity, 0);
 				gibVelocity.RadRotate(randAngle + RandomNum(0.0F, spread) + static_cast<float>(i) * goldenAngle);
+
+				if (gibSettingsObject.InheritsVelocity() > 0 && !rotatedGibOffset.IsZero()) {
+					Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
+					gibVelocity += rotationalVelocity;
+					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + m_AngularVel * gibSettingsObject.InheritsVelocity());
+				}
+
 				if (lifetime != 0) {
 					gibParticleClone->SetLifetime(std::max(static_cast<int>(static_cast<float>(lifetime) * (1.0F - lifeVariation * ((radius / maxRadius) * 0.75F + RandomNormalNum() * 0.25F))), 1));
 				}
@@ -998,7 +1005,15 @@ void MOSRotating::CreateGibsWhenGibbing(const Vector& impactImpulse, MovableObje
 				} else {
 					gibVelocity.RadRotate(gibSpread * RandomNormalNum());
 				}
+
+				if (gibSettingsObject.InheritsVelocity() > 0 && !rotatedGibOffset.IsZero()) {
+					Vector rotationalVelocity = (rotatedGibOffset.GetPerpendicular() * m_AngularVel * gibSettingsObject.InheritsVelocity()) / c_PPM;
+					gibVelocity += rotationalVelocity;
+					gibParticleClone->SetAngularVel(gibParticleClone->GetAngularVel() + m_AngularVel * gibSettingsObject.InheritsVelocity());
+				}
+
 				gibParticleClone->SetVel(gibVelocity + ((m_PrevVel + m_Vel) / 2) * gibSettingsObject.InheritsVelocity());
+
 				if (movableObjectToIgnore) {
 					gibParticleClone->SetWhichMOToNotHit(movableObjectToIgnore);
 				}


### PR DESCRIPTION
Through testing i found that gibbed MOSR's don't impart any of their AngularVel or offset-derived velocity from this AngularVel to their gibs. They do that now, and have this scaled by InheritsVel.

Additionally i found that detached attachables only inherited the plain velocity from the parent, similar to gibs. They now inherit rotational velocity in the same manner as gibs when detached.