### PR TITLE
Default and locked team techs in Activities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New `AEmitter` and `PEmitter` INI and Lua (R/W) property `PlayBurstSound` which denotes whether the BurstSound should play when appropriate. This should not be confused for a trigger - it's just a enable/disable toggle to avoid having to remove and add BurstSound altogether.
 
+- New `GameActivity` INI properties `TeamNTechSwitchEnabled` which determine whether activity team factions are configurable by the user. This is most useful for communicating what the player is not intended to change, or what inputs would be ignored otherwise.
+
 - Allow lua scripts to use LuaJIT's BitOp module (see https://bitop.luajit.org/api.html)
 
 </details>
@@ -80,6 +82,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 	`SetLimbPathPushForce(Actor.MovementState, float newValue)` sets the push force for all layers and sides of any particular movement state's limb paths, instead of being hardcoded to walking only.
 	
 - The `LimbPath` property `NormalTravelSpeed` has been renamed to just `TravelSpeed`.
+
+- `GameActivity` INI properties `TeamNTech` values switched to lazy eval, allowing them to be validated once all modules are loaded.
+	As well, the scenario menu activity configuration screen now respects defaults set in INI, where possible.
+
+- Internal GUI element `ComboBox` no longer displays dropdown combobutton when disabled, to communicate visually that it's setting is not modifiable.
 
 - Almost all ctrl+* special inputs functionality (i.e restarting activity, world dumps, showing performance stats) are now mapped to right alt, to not interfere with default crouching inputs. The only exception is ctrl+arrow keys for changing console size.
 

--- a/Source/Activities/GameActivity.cpp
+++ b/Source/Activities/GameActivity.cpp
@@ -70,7 +70,6 @@ void GameActivity::Clear() {
 		m_ReadyToStart[player] = false;
 		m_PurchaseOverride[player].clear();
 		m_BrainLZWidth[player] = BRAINLZWIDTHDEFAULT;
-		m_TeamTech[player] = "";
 		m_NetworkPlayerNames[player] = "";
 	}
 
@@ -95,6 +94,8 @@ void GameActivity::Clear() {
 
 	for (int team = Teams::TeamOne; team < Teams::MaxTeamCount; ++team) {
 		m_Deliveries[team].clear();
+		m_TeamTech[team] = "";
+		m_TeamTechSwitchEnabled[team] = true;
 		m_LandingZoneArea[team].Reset();
 		m_aLZCursor[team].clear();
 		m_aObjCursor[team].clear();
@@ -158,6 +159,7 @@ int GameActivity::Create(const GameActivity& reference) {
 	for (int team = Teams::TeamOne; team < Teams::MaxTeamCount; ++team) {
 		m_LandingZoneArea[team] = reference.m_LandingZoneArea[team];
 		m_TeamTech[team] = reference.m_TeamTech[team];
+		m_TeamTechSwitchEnabled[team] = reference.m_TeamTechSwitchEnabled[team];
 		m_TeamIsCPU[team] = reference.m_TeamIsCPU[team];
 	}
 
@@ -220,7 +222,19 @@ int GameActivity::ReadProperty(const std::string_view& propName, Reader& reader)
 		                if (propName == "Team" + std::to_string(team + 1) + "Tech") {
 			                std::string techName;
 			                reader >> techName;
-			                SetTeamTech(team, techName);
+			                m_TeamTech[team] = techName;
+		                }
+	                });
+	MatchForwards("Team1TechSwitchEnabled")
+	    MatchForwards("Team2TechSwitchEnabled")
+	        MatchForwards("Team3TechSwitchEnabled")
+	            MatchProperty(
+	                "Team4TechSwitchEnabled",
+	                for (int team = Teams::TeamOne; team < Teams::MaxTeamCount; team++) {
+		                if (propName == "Team" + std::to_string(team + 1) + "TechSwitchEnabled") {
+			                bool switchEnabled;
+			                reader >> switchEnabled;
+			                m_TeamTechSwitchEnabled[team] = switchEnabled;
 		                }
 	                });
 	MatchProperty("SpecialBehaviour_StartingGold", { reader >> m_StartingGold; });

--- a/Source/Activities/GameActivity.h
+++ b/Source/Activities/GameActivity.h
@@ -423,6 +423,8 @@ namespace RTE {
 
 		bool GetRequireClearPathToOrbitSwitchEnabled() const { return m_RequireClearPathToOrbitSwitchEnabled; }
 
+		bool GetTeamTechSwitchEnabled(int team) const { return m_TeamTechSwitchEnabled[team]; }
+
 		/// Returns CrabToHumanSpawnRatio for specified module
 		/// @return Crab-To-Human spawn ratio value set for specified module, 0.25 is default.
 		float GetCrabToHumanSpawnRatio(int moduleid);
@@ -583,6 +585,7 @@ namespace RTE {
 
 		// Tech of player
 		std::string m_TeamTech[Teams::MaxTeamCount];
+		bool m_TeamTechSwitchEnabled[Teams::MaxTeamCount];
 
 		// Initial gold amount selected by player in scenario setup dialog
 		int m_StartingGold;

--- a/Source/GUI/GUIComboBox.cpp
+++ b/Source/GUI/GUIComboBox.cpp
@@ -53,7 +53,7 @@ void GUIComboBox::Create(const std::string& Name, int X, int Y, int Width, int H
 	m_Width = std::max(m_Width, m_MinWidth);
 	m_Height = std::max(m_Height, m_MinHeight);
 
-	m_TextPanel->Create(0, 0, m_Width - 12, m_Height);
+	m_TextPanel->Create(0, 0, m_Width - 4, m_Height);
 	m_TextPanel->_SetVisible(true);
 	m_TextPanel->SetLocked((m_DropDownStyle == DropDownList));
 	m_TextPanel->SetSignalTarget(this);
@@ -89,7 +89,7 @@ void GUIComboBox::Create(GUIProperties* Props) {
 	m_Width = std::max(m_Width, m_MinWidth);
 	m_Height = std::max(m_Height, m_MinHeight);
 
-	m_TextPanel->Create(0, 0, m_Width - 12, m_Height);
+	m_TextPanel->Create(0, 0, m_Width - 4, m_Height);
 	m_TextPanel->_SetVisible(true);
 	m_TextPanel->SetSignalTarget(this);
 	GUIPanel::AddChild(m_TextPanel);
@@ -331,7 +331,7 @@ void GUIComboBox::Resize(int Width, int Height) {
 
 	GUIPanel::SetSize(Width, Height);
 
-	m_TextPanel->SetSize(m_Width - 12, m_Height);
+	m_TextPanel->SetSize(m_Width - 4, m_Height);
 	m_TextPanel->SetPositionAbs(m_X, m_Y);
 
 	m_Button->SetPositionAbs(m_X + m_Width - 13, m_Y + 1);
@@ -442,6 +442,13 @@ bool GUIComboBox::GetVisible() {
 
 void GUIComboBox::SetEnabled(bool Enabled) {
 	_SetEnabled(Enabled);
+	if (m_Button) {
+		if (Enabled) {
+			m_Button->_SetVisible(Enabled);
+		} else {
+			m_Button->_SetVisible(Enabled && _GetVisible());
+		}
+	}
 	if (m_ListPanel) {
 		m_ListPanel->_SetEnabled(Enabled);
 	}

--- a/Source/Menus/ScenarioActivityConfigGUI.cpp
+++ b/Source/Menus/ScenarioActivityConfigGUI.cpp
@@ -191,6 +191,27 @@ void ScenarioActivityConfigGUI::ResetActivityConfigBox() {
 		}
 
 		m_TeamTechComboBoxes.at(team)->SetVisible(m_SelectedActivity->TeamActive(team));
+
+		std::string teamModule = m_SelectedActivity->GetTeamTech(team);
+		int teamModuleID = g_PresetMan.GetModuleID(teamModule);
+
+		if (teamModuleID != -1) {
+			auto items = m_TeamTechComboBoxes.at(team)->GetListPanel()->GetItemList();
+			for (int i = 0; i < items->size(); i++) {
+				if (teamModuleID == items->at(i)->m_ExtraIndex) {
+					teamModuleID = i;
+				}
+			}
+			m_TeamTechComboBoxes.at(team)->SetSelectedIndex(teamModuleID);
+		} else {
+			m_TeamTechComboBoxes.at(team)->SetSelectedIndex(0);
+		}
+
+		if (!m_SelectedActivity->GetTeamTechSwitchEnabled(team)) {
+			m_TeamTechComboBoxes.at(team)->SetEnabled(false);
+			m_TeamTechComboBoxes.at(team)->SetEnabled(false);
+		}
+
 		m_TeamAISkillSliders.at(team)->SetVisible(m_SelectedActivity->TeamActive(team));
 		m_TeamAISkillLabels.at(team)->SetVisible(m_SelectedActivity->TeamActive(team));
 	}

--- a/Source/Menus/ScenarioActivityConfigGUI.cpp
+++ b/Source/Menus/ScenarioActivityConfigGUI.cpp
@@ -207,10 +207,7 @@ void ScenarioActivityConfigGUI::ResetActivityConfigBox() {
 			m_TeamTechComboBoxes.at(team)->SetSelectedIndex(0);
 		}
 
-		if (!m_SelectedActivity->GetTeamTechSwitchEnabled(team)) {
-			m_TeamTechComboBoxes.at(team)->SetEnabled(false);
-			m_TeamTechComboBoxes.at(team)->SetEnabled(false);
-		}
+		m_TeamTechComboBoxes.at(team)->SetEnabled(m_SelectedActivity->GetTeamTechSwitchEnabled(team));
 
 		m_TeamAISkillSliders.at(team)->SetVisible(m_SelectedActivity->TeamActive(team));
 		m_TeamAISkillLabels.at(team)->SetVisible(m_SelectedActivity->TeamActive(team));


### PR DESCRIPTION
Added Activity .ini properties TeamNTechSwitchEnabled, updated property TeamNTech to not safety check for installed mods, as the code actually can not know which mods are installed until after loading. Updated ComboBox code to not display the ComboButton while disabled, and display content at full width when disabled. Updated the ScenarioActivityConfigGUI to respect which faction is default selected and whether the team's faction is editable. Now an activity may specify default factions and lock the important ones.