### PR TITLE
Enable Luabind error checking on linux

### DIFF
--- a/external/sources/luabind-0.7.1/meson.build
+++ b/external/sources/luabind-0.7.1/meson.build
@@ -20,10 +20,6 @@ elif cxx.get_argument_syntax() == 'msvc'
   cpp_options = ['cpp_std=vc++20']
 endif
 
-if (not get_option('debug')) or get_option('debug_type') == 'release'
-  luabind_args += ['-DLUABIND_NO_ERROR_CHECKING=1']
-endif
-
 luabind = static_library('luabind071', luabind_src, dependencies: luabind_dependencies, include_directories:luabind_include, cpp_args:cpp_args+ luabind_args, override_options: ['warning_level=0']+ cpp_options)
 
 luabind_dep = declare_dependency(link_with: luabind, dependencies: deps, include_directories: luabind_include, compile_args: luabind_args)


### PR DESCRIPTION
The source of a bunch of issues on linux. A lot of them probably MT related, since with error checking enabled, there are no additional errors, but it doesn't crash anymore.