### PR TITLE
Inventory Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed an issue where internal Lua functions OriginalDoFile, OriginalLoadFile, and OriginalRequire were polluting the global namespace. They have now been made inaccessible.
 
+- Various fixes and improvements to inventory management when dual-wielding or carrying a shield, to stop situations where the actor unexpectedly puts their items away.
+
 </details>
 
 <details><summary><b>Removed</b></summary>

--- a/Resources/Credits.h
+++ b/Resources/Credits.h
@@ -8,7 +8,8 @@ R"(- C O R T E X   C O M M A N D   C O M M U N I T Y   P R O J E C T -
 
 Programming
 3 4 3 N
-A L B E R T O  " T H E P A W N "  K U R T Y A N
+A L B E R T O   " T H E P A W N "   K U R T Y A N
+B I T   G H O S T
 C O M R A D E S H O O K
 E V G E N I Y   " W E E G E E "   V I G O V S K I Y
 F R I S 0 U M A N

--- a/Source/Entities/AHuman.cpp
+++ b/Source/Entities/AHuman.cpp
@@ -998,7 +998,7 @@ bool AHuman::EquipShield() {
 	return false;
 }
 
-bool AHuman::EquipShieldInBGArm() {
+bool AHuman::EquipShieldInBGArm(bool depositToFront) {
 	if (!(m_pBGArm && m_pBGArm->IsAttached())) {
 		return false;
 	}
@@ -1007,7 +1007,11 @@ bool AHuman::EquipShieldInBGArm() {
 		// If we're holding a shield, but aren't supposed to, because we need to support the FG hand's two-handed device, then let go of the shield and put it back in inventory.
 		if (m_pFGArm && m_pFGArm->IsAttached() && m_pFGArm->GetHeldDevice() && !m_pFGArm->GetHeldDevice()->IsOneHanded()) {
 			m_pBGArm->GetHeldDevice()->Deactivate();
-			AddToInventoryBack(m_pBGArm->RemoveAttachable(heldDevice));
+			if (depositToFront) {
+				AddToInventoryFront(m_pBGArm->RemoveAttachable(heldDevice));
+			} else {
+				AddToInventoryBack(m_pBGArm->RemoveAttachable(heldDevice));
+			}
 			return false;
 		}
 		return true;
@@ -1030,7 +1034,11 @@ bool AHuman::EquipShieldInBGArm() {
 			// Put back into the inventory what we had in our hands, if anything
 			if (HeldDevice* heldDevice = m_pBGArm->GetHeldDevice()) {
 				heldDevice->Deactivate();
-				AddToInventoryBack(m_pBGArm->RemoveAttachable(heldDevice));
+				if (depositToFront) {
+					AddToInventoryFront(m_pBGArm->RemoveAttachable(heldDevice));
+				} else {
+					AddToInventoryBack(m_pBGArm->RemoveAttachable(heldDevice));
+				}
 			}
 
 			// Now put the device we were looking for and found into the hand
@@ -1565,7 +1573,6 @@ void AHuman::PreControllerUpdate() {
 		}
 		// Disengage the prone state as soon as prone is released.
 		if (!prone && m_ProneState != NOTPRONE) {
-			EquipShieldInBGArm();
 			m_ProneState = NOTPRONE;
 		}
 	}
@@ -1613,7 +1620,7 @@ void AHuman::PreControllerUpdate() {
 				} else {
 					m_pFGArm->SetHeldDevice(dynamic_cast<HeldDevice*>(SwapPrevInventory(m_pFGArm->RemoveAttachable(m_pFGArm->GetHeldDevice()))));
 				}
-				EquipShieldInBGArm();
+				EquipShieldInBGArm(!changeNext);
 				m_pFGArm->SetHandPos(m_Pos + RotateOffset(m_HolsterOffset));
 			}
 			m_EquipHUDTimer.Reset();
@@ -2306,9 +2313,9 @@ void AHuman::PreControllerUpdate() {
 		if (m_Status == STABLE) {
 			if (m_ArmClimbing[BGROUND]) {
 				// Can't climb or crawl with the shield
-				if (m_MovementState != CRAWL || m_ProneState == LAYINGPRONE) {
-					UnequipBGArm();
-				}
+				// if (m_MovementState != CRAWL || m_ProneState == LAYINGPRONE) {
+				//	UnequipBGArm();
+				//}
 				m_pBGArm->AddHandTarget("Hand AtomGroup Limb Pos", m_pBGHandGroup->GetLimbPos(m_HFlipped));
 			} else {
 				HeldDevice* heldDevice = GetEquippedItem();

--- a/Source/Entities/AHuman.h
+++ b/Source/Entities/AHuman.h
@@ -301,7 +301,7 @@ namespace RTE {
 		/// this only works if nothing is held at all, or the FG arm holds a
 		/// one-handed device, or we're in inventory mode.
 		/// @return Whether a shield was successfully equipped in the background arm.
-		bool EquipShieldInBGArm();
+		bool EquipShieldInBGArm(bool depositToFront = false);
 
 		/// Tries to equip the first dual-wieldable in inventory to the background arm;
 		/// this only works if nothing is held at all, or the FG arm holds a

--- a/Source/Lua/LuaBindingsEntities.cpp
+++ b/Source/Lua/LuaBindingsEntities.cpp
@@ -442,7 +442,7 @@ LuaBindingRegisterFunctionDefinitionForType(EntityLuaBindings, AHuman) {
 	    .def("EquipThrowable", &AHuman::EquipThrowable)
 	    .def("EquipDiggingTool", &AHuman::EquipDiggingTool)
 	    .def("EquipShield", &AHuman::EquipShield)
-	    .def("EquipShieldInBGArm", &AHuman::EquipShieldInBGArm)
+	    .def("EquipShieldInBGArm", (bool(AHuman::*)()) & AHuman::EquipShieldInBGArm)
 	    .def("EquipDeviceInGroup", &AHuman::EquipDeviceInGroup)
 	    .def("EquipNamedDevice", (bool(AHuman::*)(const std::string&, bool)) & AHuman::EquipNamedDevice)
 	    .def("EquipNamedDevice", (bool(AHuman::*)(const std::string&, const std::string&, bool)) & AHuman::EquipNamedDevice)


### PR DESCRIPTION
Removes code to put away offhand automatically, and code to take out offhand automatically, both of which are typically aggravating in stressful situations where they may be triggered in error, such as trying to scurry in cramped halls while holding a shield.

Also adds code to ensure an offhand is discarded to the same side of the inventory as the onhand.

This is prelude to a minor inventory overhaul aimed at keeping order over time so that your inventory doesn't shuffle unless you're trying to shuffle it, but I don't know how exactly that'd work yet.