### PR TITLE
Null NextSongSection properly - fix Mac/Linux crash when playing DynamicSongs

### DIFF
--- a/Source/Entities/DynamicSong.cpp
+++ b/Source/Entities/DynamicSong.cpp
@@ -166,6 +166,8 @@ SoundContainer& DynamicSongSection::SelectTransitionSoundContainer() {
 }
 
 SoundContainer& DynamicSongSection::SelectSoundContainer() {
+	RTEAssert(!m_SoundContainers.empty(), "Tried to get a SoundContainer from a DynamicSongSection with none to choose from!");
+	
 	// Shuffle between our options if we have multiple
 	if (m_SoundContainers.size() != 1) {
 		if (m_ShuffleUnplayedIndices.empty()) {
@@ -198,8 +200,7 @@ SoundContainer& DynamicSongSection::SelectSoundContainer() {
 			}
 		}
 	}
-
-	RTEAssert(!m_SoundContainers.empty(), "Tried to get a SoundContainer from a DynamicSongSection with none to choose from!");
+	
 	return m_SoundContainers[0];
 }
 

--- a/Source/Managers/MusicMan.cpp
+++ b/Source/Managers/MusicMan.cpp
@@ -100,6 +100,7 @@ void MusicMan::ResetMusicState() {
 
 bool MusicMan::PlayDynamicSong(const std::string& songName, const std::string& songSectionType, bool playImmediately, bool playTransition, bool smoothFade) {
 	if (const DynamicSong* dynamicSongToPlay = dynamic_cast<const DynamicSong*>(g_PresetMan.GetEntityPreset("DynamicSong", songName))) {
+		m_NextSongSection = nullptr;
 		m_CurrentSong = std::unique_ptr<DynamicSong>(dynamic_cast<DynamicSong*>(dynamicSongToPlay->Clone()));
 		SetNextSongSectionType(songSectionType);
 		SelectNextSongSection();


### PR DESCRIPTION
On Windows this was use-after-free, but on Mac/Linux it was apparently getting zeroed and would later be empty, which would cause a crash that an assert was supposed to prevent but didn't due to being misplaced.

I can't test this because I'm on Windows, but it should fix the described issue.

Fixes #161