### PR TITLE
Fix init resolution check

### DIFF
--- a/Source/GUI/GUIInput.cpp
+++ b/Source/GUI/GUIInput.cpp
@@ -1,4 +1,3 @@
-#include "GUIInput.h"
 #include "GUI.h"
 
 using namespace RTE;

--- a/Source/GUI/GUIInput.cpp
+++ b/Source/GUI/GUIInput.cpp
@@ -1,3 +1,4 @@
+#include "GUIInput.h"
 #include "GUI.h"
 
 using namespace RTE;
@@ -147,4 +148,15 @@ void GUIInput::Update() {
 
 int GUIInput::GetModifier() const {
 	return m_Modifier;
+}
+
+void GUIInput::StartTextInput() {
+	m_TextInputActive++;
+}
+
+void GUIInput::StopTextInput() {
+	m_TextInputActive--;
+	if (m_TextInputActive < 0) {
+		m_TextInputActive = 0;
+	}
 }

--- a/Source/GUI/GUIInput.h
+++ b/Source/GUI/GUIInput.h
@@ -122,6 +122,12 @@ namespace RTE {
 		/// @param enableKeyJoyMouseCursor Whether the keyboard and joysticks also control the mouse or not.
 		void SetKeyJoyMouseCursor(bool enableKeyJoyMouseCursor) { m_KeyJoyMouseCursor = enableKeyJoyMouseCursor; }
 
+		/// Enables receiving text input events.
+		virtual void StartTextInput();
+
+		/// Disables receiving text input events.
+		virtual void StopTextInput();
+
 	protected:
 		enum Constants {
 			KEYBOARD_BUFFER_SIZE = 256
@@ -132,6 +138,7 @@ namespace RTE {
 		unsigned char m_ScanCodeState[KEYBOARD_BUFFER_SIZE];
 		std::string m_TextInput;
 		bool m_HasTextInput;
+		int m_TextInputActive{0};
 
 		// Mouse button states
 		// Order:    Left, Middle, Right

--- a/Source/GUI/GUITextPanel.cpp
+++ b/Source/GUI/GUITextPanel.cpp
@@ -140,6 +140,14 @@ void GUITextPanel::Draw(GUIScreen* Screen) {
 	Screen->GetBitmap()->SetClipRect(nullptr);
 }
 
+void GUITextPanel::OnGainFocus() {
+	m_Manager->GetInputController()->StartTextInput();
+}
+
+void GUITextPanel::OnLoseFocus() {
+	m_Manager->GetInputController()->StopTextInput();
+}
+
 void GUITextPanel::OnKeyPress(int KeyCode, int Modifier) {
 	// TODO: Figure out what the "performance bitching" is.
 	// Condition here to stop the compiler bitching about performance

--- a/Source/GUI/GUITextPanel.h
+++ b/Source/GUI/GUITextPanel.h
@@ -35,6 +35,14 @@ namespace RTE {
 		/// @param Screen Screen class
 		void Draw(GUIScreen* Screen) override;
 
+		/// Called when this panel gains focus.
+		/// Start text input events.
+		void OnGainFocus() override;
+
+		/// Called when this panel loses focus.
+		/// Stops text input events.
+		void OnLoseFocus() override;
+
 		/// Called when the mouse goes down on the panel
 		/// @param X Mouse Position, Mouse Buttons, Modifier.
 		void OnMouseDown(int X, int Y, int Buttons, int Modifier) override;
@@ -51,6 +59,7 @@ namespace RTE {
 		/// @param KeyCode KeyCode, Modifier.
 		void OnKeyPress(int KeyCode, int Modifier) override;
 
+		/// Called when text input is received
 		void OnTextInput(std::string_view inputText) override;
 
 		/// Sets the text in the textpanel.

--- a/Source/GUI/Wrappers/GUIInputWrapper.cpp
+++ b/Source/GUI/Wrappers/GUIInputWrapper.cpp
@@ -1,5 +1,7 @@
 #include "GUI.h"
 #include "GUIInputWrapper.h"
+#include "GUIInput.h"
+#include "SDL3/SDL_keyboard.h"
 #include "WindowMan.h"
 #include "FrameMan.h"
 #include "UInputMan.h"
@@ -60,6 +62,18 @@ void GUIInputWrapper::Update() {
 	Vector mousePos = g_UInputMan.GetAbsoluteMousePosition(m_Player);
 	m_MouseX = static_cast<int>(mousePos.GetX() / static_cast<float>(g_WindowMan.GetResMultiplier()));
 	m_MouseY = static_cast<int>(mousePos.GetY() / static_cast<float>(g_WindowMan.GetResMultiplier()));
+}
+
+void GUIInputWrapper::StartTextInput() {
+	GUIInput::StartTextInput();
+	SDL_StartTextInput(g_WindowMan.GetWindow());
+}
+
+void GUIInputWrapper::StopTextInput() {
+	GUIInput::StopTextInput();
+	if (m_TextInputActive <= 0) {
+		SDL_StopTextInput(g_WindowMan.GetWindow());
+	}
 }
 
 void GUIInputWrapper::UpdateKeyboardInput(float keyElapsedTime) {

--- a/Source/GUI/Wrappers/GUIInputWrapper.cpp
+++ b/Source/GUI/Wrappers/GUIInputWrapper.cpp
@@ -1,7 +1,6 @@
 #include "GUI.h"
 #include "GUIInputWrapper.h"
-#include "GUIInput.h"
-#include "SDL3/SDL_keyboard.h"
+#include "SDL3/SDL.h"
 #include "WindowMan.h"
 #include "FrameMan.h"
 #include "UInputMan.h"

--- a/Source/GUI/Wrappers/GUIInputWrapper.h
+++ b/Source/GUI/Wrappers/GUIInputWrapper.h
@@ -29,6 +29,10 @@ namespace RTE {
 #pragma region Virtual Override Methods
 		/// Updates the input.
 		void Update() override;
+
+		void StartTextInput() override;
+
+		void StopTextInput() override;
 #pragma endregion
 
 	private:

--- a/Source/GUI/Wrappers/GUIInputWrapper.h
+++ b/Source/GUI/Wrappers/GUIInputWrapper.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "GUIInput.h"
-#include <SDL3/SDL_scancode.h>
+#include "SDL3/SDL_scancode.h"
 
 #include <array>
 #include <memory>

--- a/Source/Managers/WindowMan.cpp
+++ b/Source/Managers/WindowMan.cpp
@@ -1,4 +1,7 @@
 #include "WindowMan.h"
+#include "RTEError.h"
+#include "SDL3/SDL_error.h"
+#include "SDL3/SDL_video.h"
 #include "SettingsMan.h"
 #include "FrameMan.h"
 #include "ActivityMan.h"
@@ -96,7 +99,20 @@ void WindowMan::Destroy() {
 void WindowMan::Initialize() {
 	SDL_free(SDL_GetDisplays(&m_NumDisplays));
 
-	SDL_Rect currentDisplayBounds;
+	m_PrimaryWindowDisplayIndex = SDL_GetPrimaryDisplay();
+	if (m_PrimaryWindowDisplayIndex == 0) {
+		g_ConsoleMan.PrintString("ERROR: Failed to get primary display!" + std::string(SDL_GetError()));
+		int count{0};
+		SDL_DisplayID* displays = SDL_GetDisplays(&count);
+		if (displays) {
+			m_PrimaryWindowDisplayIndex = displays[0];
+		} else {
+			RTEAbort("No displays detetected somehow! " + std::string(SDL_GetError()));
+		}
+		SDL_free(displays);
+	}
+
+	SDL_Rect currentDisplayBounds{};
 	SDL_GetDisplayBounds(m_PrimaryWindowDisplayIndex, &currentDisplayBounds);
 
 	m_PrimaryWindowDisplayWidth = currentDisplayBounds.w;
@@ -160,7 +176,6 @@ void WindowMan::CreatePrimaryWindow() {
 
 	int windowPosX = (m_ResX * m_ResMultiplier <= m_PrimaryWindowDisplayWidth) ? SDL_WINDOWPOS_CENTERED : (m_MaxResX - (m_ResX * m_ResMultiplier)) / 2;
 	int windowPosY = SDL_WINDOWPOS_CENTERED;
-	int windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
 
 	SDL_PropertiesID windowProps = SDL_CreateProperties();
 	RTEAssert(windowProps, "Unable to create window properties! " + std::string(SDL_GetError()));


### PR DESCRIPTION
Was using display index 0 by default, which is illegal in sdl3 causing some uninitialized variables! (using GetPrimaryDisplay instead now to get primary display)

Also fixed text input not being enabled (although that should have been broken in sdl2 as well)