### PR TITLE
Fixed Seeray Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed a minor inconsistency where `ACDropShip`s were frequently referred to as `ACDropship`s in Lua, the lower case 's' invalidating keywords where the typo occured.
 
+- Fixed an issue where the buy menu GUI could ignore mouse hover events until you clicked to reset the focus.
+
 </details>
 
 <details><summary><b>Removed</b></summary>

--- a/Source/Managers/MovableMan.cpp
+++ b/Source/Managers/MovableMan.cpp
@@ -12,7 +12,6 @@
 #include "Controller.h"
 #include "AtomGroup.h"
 #include "Actor.h"
-#include "HeldDevice.h"
 #include "ADoor.h"
 #include "Atom.h"
 #include "Scene.h"
@@ -1314,6 +1313,9 @@ void MovableMan::Update() {
 		g_SceneMan.GetScene()->BlockUntilAllPathingRequestsComplete();
 	}
 
+	// Finish our Seeing rays from last frame
+	m_ActorsSeeFuture.wait();
+
 	// Prior to controller/AI update, execute lua callbacks
 	g_LuaMan.ExecuteLuaScriptCallbacks();
 
@@ -1395,18 +1397,6 @@ void MovableMan::Update() {
 	g_PerformanceMan.StopPerformanceMeasurement(PerformanceMan::ScriptsUpdate);
 
 	{
-		auto actorsSeeFuture = g_ThreadMan.GetPriorityThreadPool().parallelize_loop(m_Actors.size(),
-		                                                                            [&](int start, int end) {
-			                                                                            ZoneScopedN("Actors See");
-			                                                                            for (int i = start; i < end; ++i) {
-																							m_Actors[i]->CastSeeRays();
-			                                                                            }
-		                                                                            });
-
-		// TODO- right now RemoveActor just removes to actor directly (instead of setting it disabled and delaying the actual remoal), meaning that actorsSeeFuture must be finished immediately
-		// This isn't ideal, as we'd prefer to be able to run the actor/items/particle update in parallel
-		actorsSeeFuture.wait();
-
 		{
 			ZoneScopedN("Actors Update");
 
@@ -1478,9 +1468,6 @@ void MovableMan::Update() {
 				particle->PostUpdate();
 			}
 		}
-		
-		// See above TODO - this is only commented out because of how RemoveActor currently works
-		//actorsSeeFuture.wait();
 	} // namespace RTE
 
 	//////////////////////////////////////////////////////////////////////
@@ -1679,6 +1666,15 @@ void MovableMan::Update() {
 			m_Particles.erase(midIt, m_Particles.end());
 		}
 	}
+
+	// Run seeing rays for all actors
+	m_ActorsSeeFuture = g_ThreadMan.GetPriorityThreadPool().parallelize_loop(m_Actors.size(),
+	                                                                         [&](int start, int end) {
+		                                                                         ZoneScopedN("Actors See");
+		                                                                         for (int i = start; i < end; ++i) {
+			                                                                         m_Actors[i]->CastSeeRays();
+		                                                                         }
+	                                                                         });
 
 	// We've finished stuff that can interact with lua script, so it's the ideal time to start a gc run
 	g_LuaMan.StartAsyncGarbageCollection();

--- a/Source/Managers/MovableMan.cpp
+++ b/Source/Managers/MovableMan.cpp
@@ -1399,13 +1399,13 @@ void MovableMan::Update() {
 		                                                                            [&](int start, int end) {
 			                                                                            ZoneScopedN("Actors See");
 			                                                                            for (int i = start; i < end; ++i) {
-																							// TODO - this null check really shouldn't be required. There's almost definitely an issue where the actor update can somehow fuck with this mid-update
-																							// this is VERY bad, and needs investigation!
-																							if (m_Actors[i]) { 
-																								m_Actors[i]->CastSeeRays();
-																							}
+																							m_Actors[i]->CastSeeRays();
 			                                                                            }
 		                                                                            });
+
+		// TODO- right now RemoveActor just removes to actor directly (instead of setting it disabled and delaying the actual remoal), meaning that actorsSeeFuture must be finished immediately
+		// This isn't ideal, as we'd prefer to be able to run the actor/items/particle update in parallel
+		actorsSeeFuture.wait();
 
 		{
 			ZoneScopedN("Actors Update");
@@ -1478,8 +1478,9 @@ void MovableMan::Update() {
 				particle->PostUpdate();
 			}
 		}
-
-		actorsSeeFuture.wait();
+		
+		// See above TODO - this is only commented out because of how RemoveActor currently works
+		//actorsSeeFuture.wait();
 	} // namespace RTE
 
 	//////////////////////////////////////////////////////////////////////

--- a/Source/Managers/MovableMan.h
+++ b/Source/Managers/MovableMan.h
@@ -9,6 +9,8 @@
 #include "Singleton.h"
 #include "Activity.h"
 
+#include "BS_thread_pool.hpp"
+
 #include <mutex>
 #include <map>
 #include <future>
@@ -595,6 +597,9 @@ namespace RTE {
 
 		// Async to draw MOIDs while rendering
 		std::future<void> m_DrawMOIDsTask;
+
+		// Async to have actors see in parallel
+		BS::multi_future<void> m_ActorsSeeFuture;
 
 		// Roster of each team's actors, sorted by their X positions in the scene. Actors not owned here
 		std::list<Actor*> m_ActorRoster[Activity::MaxTeamCount];

--- a/Source/Menus/BuyMenuGUI.cpp
+++ b/Source/Menus/BuyMenuGUI.cpp
@@ -744,6 +744,9 @@ void BuyMenuGUI::Update() {
 	// Animate the menu into and out of view if enabled or disabled
 
 	if (m_MenuEnabled == ENABLING) {
+		// Make sure that nobody can hoard focus away from us
+		m_pGUIController->GetManager()->ReleaseMouse();
+
 		m_pParentBox->SetEnabled(true);
 		m_pParentBox->SetVisible(true);
 

--- a/Source/System/RTETools.cpp
+++ b/Source/System/RTETools.cpp
@@ -50,19 +50,6 @@ namespace RTE {
 		float angleDelta = std::fmod(endRot.GetRadAngle() - startRot.GetRadAngle(), fullTurn);
 		float angleDistance = std::fmod(angleDelta * 2.0F, fullTurn) - angleDelta;
 		return Matrix(startRot.GetRadAngle() + (angleDistance * Lerp(scaleStart, scaleEnd, 0.0F, 1.0F, progressScalar)));
-
-		float startRad = startRot.GetRadAngle();
-		float endRad = endRot.GetRadAngle();
-		float diff = startRad - endRad;
-		if (diff > c_PI) {
-			std::swap(startRad, endRad);
-			diff -= c_PI;
-		} else if (diff < -c_PI) {
-			std::swap(startRad, endRad);
-			diff += c_PI;
-		}
-
-		return Matrix(startRad + (diff * Lerp(scaleStart, scaleEnd, 0.0F, 1.0F, progressScalar)));
 	}
 
 	float EaseIn(float start, float end, float progressScalar) {


### PR DESCRIPTION
Fixes crash when script modifies actors that are seeing, and improves performance by giving a full frame of latency (with one frame delayed seeing)

Also fixes a minor issue where the buy menu GUI could ignore hover events if you clicked on certain elements to take focus away before closing and reopening the menu