### PR TITLE
Fix release

### DIFF
--- a/.github/actions/bundle_release/action.yaml
+++ b/.github/actions/bundle_release/action.yaml
@@ -20,7 +20,7 @@ runs:
         zip --must-match -j CortexCommand.windows.zip \
           release/Cortex\ Command*/Cortex\ Command*.exe \
           release/Cortex\ Command*/Cortex\ Command*.pdb \
-          external/lib/win/{fmod,SDL2}.dll
+          external/lib/win/fmod.dll
 
     - name: Compress Linux Release
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
     types: [checks_requested]
 
   workflow_dispatch:
+  
+  schedule:
+    - cron: '1 0 * * 0'
 
 # Cancel in-progress runs if newer changes to the same branch/PR are pushed.
 concurrency:


### PR DESCRIPTION
- remove SDL2 from windows release bundle
- add keepalive task to maybe keep the macos build cache (runs weekly (for 2 months, resets with activity in the repo (github limit)))