### PR TITLE
Fixed Missing Buy Cart Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,27 +16,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 	New `Actor` Lua property `JumpHeight` (R) to estimate the jump height of the actor (in metres), based on the actor's jetpack and weight. Actors without a jetpack return 0.  
 	The new function `GetPathFindingFlyingJumpHeight()` can be used to get a jumpHeight that allows flying (i.e infinite jump height). This is also the value that `ACRocket`s and `ACDropShip`s return for `JumpHeight`.
 
-- Improved locomotion.
-	Added the ability to run. When running, you cannot sharpaim whatsoever.
-	Added the ability to manually crouch. When crouching, your sharpaim distance is slightly increased.
-	Players on PC can enable running by holding the shift key, or crouch by holding control. Players using the arrow keys can use right ctrl/shift. Controllers can run by clicking in the left stick, or crouch by holding the left stick down. Prone on controllers is now performed by clicking in the right stick. SNES/d-pad controllers run using the right bumper.
-	Prone input now immediately throws you to the ground instead of crouching first.
-	Added new `MovementState` type `RUN` for scripts.
-	Added new `Controller` state `WALKCROUCH` for crouching, and `PRONE` for prone. The existing `CROUCH` state has been deprecated, as it referred to PRONE.
-	Added new `Actor` INI and Lua (R/W) property `CanRun` which denotes whether the Actor can run or not.
+- Improved locomotion.  
+	Added the ability to run. When running, you cannot sharpaim whatsoever.  
+	Added the ability to manually crouch. When crouching, your sharpaim distance is slightly increased.  
+	Players on PC can enable running by holding the shift key, or crouch by holding control. Players using the arrow keys can use right ctrl/shift. Controllers can run by clicking in the left stick, or crouch by holding the left stick down. Prone on controllers is now performed by clicking in the right stick. SNES/d-pad controllers run using the right bumper.  
+	Prone input now immediately throws you to the ground instead of crouching first.  
+	Added new `MovementState` type `RUN` for scripts.  
+	Added new `Controller` state `WALKCROUCH` for crouching, and `PRONE` for prone. The existing `CROUCH` state has been deprecated, as it referred to PRONE.  
+	Added new `Actor` INI and Lua (R/W) property `CanRun` which denotes whether the Actor can run or not.  
 	Added new `Actor` INI and Lua (R/W) property `CrouchWalkSpeedMultiplier` which is a walking speed multiplier when at max crouch amount.
 
-- New hotkey system for `Actor` and `HeldDevice`.
-	Pressing a certain new hotkey will mark it as activated on `Actor` and `HeldDevice`, letting scripts make use of the new bindings easily.
+- New hotkey system for `Actor` and `HeldDevice`.  
+	Pressing a certain new hotkey will mark it as activated on `Actor` and `HeldDevice`, letting scripts make use of the new bindings easily.  
 	`Enum` binding for `HeldDevice.HeldDeviceHotkeyType`: `PRIMARYHOTKEY = 0, AUXILIARYHOTKEY = 1, HELDDEVICEHOTKEYTYPECOUNT = 2`.  
-	`Enum` binding for `Actor.ActorHotkeyType`: `PRIMARYHOTKEY = 0, AUXILIARYHOTKEY = 1, ACTORHOTKEYTYPECOUNT = 2`. 
-	Both `Actor` and `HeldDevice` have the following functions:
-	`HotkeyActionIsActivated(hotkeyType)` returns whether a certain hotkey action is being activated or not.
-	`ActivateHotkeyAction(hotkeyType)` activates a certain hotkey action.
+	`Enum` binding for `Actor.ActorHotkeyType`: `PRIMARYHOTKEY = 0, AUXILIARYHOTKEY = 1, ACTORHOTKEYTYPECOUNT = 2`.  
+	Both `Actor` and `HeldDevice` have the following functions:  
+	`HotkeyActionIsActivated(hotkeyType)` returns whether a certain hotkey action is being activated or not.  
+	`ActivateHotkeyAction(hotkeyType)` activates a certain hotkey action.  
 	`DeactivateHotkeyAction(hotkeyType)` deactivates a certain hotkey action.
 
-- New hotkey bindings.
-	On Mouse+KB PC the defaults are: Weapon Primary Hotkey on V, Weapon Auxiliary Hotkey on H, Actor Primary Hotkey on X, Actor Auxiliary Hotkey on O.
+- New hotkey bindings.  
+	On Mouse+KB PC the defaults are: Weapon Primary Hotkey on V, Weapon Auxiliary Hotkey on H, Actor Primary Hotkey on X, Actor Auxiliary Hotkey on O.  
 	Added new `Controller` states `WEAPON_PRIMARY_HOTKEYSTART`, `WEAPON_AUXILIARY_HOTKEYSTART`, `ACTOR_PRIMARY_HOTKEYSTART`, `ACTOR_AUXILIARY_HOTKEYSTART`, `WEAPON_PRIMARY_HOTKEY`, `WEAPON_AUXILIARY_HOTKEY`, `ACTOR_PRIMARY_HOTKEY`, `ACTOR_AUXILIARY_HOTKEY`
 
 - Added multiseat support for multiple mice and keyboards on one computer.
@@ -44,8 +44,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added optional player argument to all `UInputMan:Key*` Lua Methods. (e.g. `KeyHeld(keycode, player)`) This allows checking individual player's keyboards, when multiple keyboards are available.
 
 - New music system, including a dynamic horizontal sequencing system, under the new music manager `MusicMan`.  
-	`PlayDynamicSong(string songName, string songSectionName, bool playImmediately, bool playTransition, bool smoothFade)` to play a new DynamicSong.
-	`SetNextDynamicSongSection(string songSectionName, bool playImmediately, bool playTransition, bool smoothFade)` to queue a new DynamicSongSection for the currently playing song.  
+	`PlayDynamicSong(string songName, string songSectionName, bool playImmediately, bool playTransition, bool smoothFade)` to play a new DynamicSong.  
+	`SetNextDynamicSongSection(string songSectionName, bool playImmediately, bool playTransition, bool smoothFade)` to queue a new DynamicSongSection for the currently playing song.   
 	`PlayInterruptingMusic(SoundContainer soundContainer)` to start an interrupting piece of music which will pause any playing DynamicSong. Note that pause menu music happily overrides this currently.  
 	`EndInterruptingMusic()` to end any playing interrupting music, and resume any paused DynamicSongs.  
 	`EndDynamicMusic(bool fadeOut)` to end any currently playing dynamic music, optionally immediately fading it out. If not fading it out, the currently playing piece will play to completion.  
@@ -59,9 +59,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 	Lua property `Paused` (R/W) to pause or unpause all sounds of a SoundContainer. Newly played sounds will not begin playback until unpaused.  
 	Lua function `GetAudibleVolume` to get the real audible volume of a SoundContainer's sounds as a float from 0 to 1. This accounts for literally everything, including game volume.
 
-- New `LimbPath` features.
-	New `LimbPath` INI and Lua (R/W) property `BaseTravelSpeedMultiplier` which is a multiplier on the TravelSpeed of that LimbPath, on top of any other gameplay multipliers like from crouching.
-	New `LimbPath` INI and Lua (R/W) property `BaseScaleMultiplier`, which is a vector. This will scale the X/Y axes of the limbpath accordingly, allowing for easily adjusting limbpaths to differently sized actors, on top of any other gameplay multipliers like from running.
+- New `LimbPath` features.  
+	New `LimbPath` INI and Lua (R/W) property `BaseTravelSpeedMultiplier` which is a multiplier on the TravelSpeed of that LimbPath, on top of any other gameplay multipliers like from crouching.  
+	New `LimbPath` INI and Lua (R/W) property `BaseScaleMultiplier`, which is a vector. This will scale the X/Y axes of the limbpath accordingly, allowing for easily adjusting limbpaths to differently sized actors, on top of any other gameplay multipliers like from running.  
 	New `LimbPath` INI property `SegmentEndedThreshold`, which defines the distance the limb must be from the end of the segment before it's considered complete. This defaults to 2.5.  
 	Exposed `LimbPath` properties `TravelSpeed` and `PushForce` to Lua (R/W).
 
@@ -71,8 +71,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 	
 - New `Controller` state `WEAPON_RELOADHELD`, which is true every frame reload input is held (as opposed to `WEAPON_RELOAD` which is only true once when pressed).
 
-- New `GAScripted` Lua script method `IsCompatibleScene(scene)` to allow Activities to generically decide which Scenes are eligible by returning a boolean value.
-	New `GAScripted` INI enumerating property `AddRequiredArea`, replacing Lua file scanning, to allow Activities to explicitly state which areas are strictly required.
+- New `GAScripted` Lua script method `IsCompatibleScene(scene)` to allow Activities to generically decide which Scenes are eligible by returning a boolean value.  
+	New `GAScripted` INI enumerating property `AddRequiredArea`, replacing Lua file scanning, to allow Activities to explicitly state which areas are strictly required.  
 	As before, these work in tandem. Both the required areas, if defined, and script conditional method, if defined, must pass for the scene to qualify.
 
 - New `GameActivity` INI properties `TeamNTechSwitchEnabled` which determine whether activity team factions are configurable by the user. This is most useful for communicating what the player is not intended to change, or what inputs would be ignored otherwise.
@@ -86,7 +86,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New `Attachable` INI and Lua (R/W) properties `InheritsVelWhenDetached` and `InheritsAngularVelWhenDetached`, which determine how much of these velocities an attachable inherits from its parent when detached. Defaults to 1.
 
 - New Z Order for scene layers and primitives: Background layer sits at z=100, Terrain Background at z=50, Terrain color and MO color at z=0, GUIs sit at z=-100, allowed z range is [-200, +200], in the future this'll be expanded to MO draw as well.
-- Added Lua-accessible bitmap manipulation functions to `MOSprite`s:	
+
+- Added Lua-accessible bitmap manipulation functions to `MOSprite`:  
 	```
 	GetSpritePixelIndex(int x, int y, int whichFrame) - Returns the color index of the pixel at the given coordinate on the given frame of the sprite ((0, 0) is the upper left corner!)
 
@@ -100,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  
 	SetAllVisibleSpritePixelIndexes(int colorIndex) - Simplified version of the above, sets all visible pixels of the currently visible sprite to the given color index.
 	```
+
 - Added `Material` Lua function `GetColorIndex()`, which returns the color index of the calling material.
 
 - New `ACraft` INI and Lua (R/W) property `CanEnterOrbit`, which determines whether a craft can enter orbit (and refund gold appropriately) or not. If false, default out-of-bounds deletion logic applies.
@@ -110,14 +112,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - New parameter `depth` for all primitives sets draw depth of the drawn primitive. The default depth is -75.0 (lower numbers draw on top, higher numbers in the back). 
 
-- New `DrawDepth` enum for default draw depths:
-   - `Default` = 0.0f (Main draw depth for MOs)
-   - `GUI` = -100.0f (Draw Depth of GUI elements)
-   - `Primitive` = -75.0f (Default Primitive draw depth)
-   - `TerrainBackground` = 50.0f (Draw Depth of Terrain Background layer)
+- New `DrawDepth` enum for default draw depths:  
+   - `Default` = 0.0f (Main draw depth for MOs)  
+   - `GUI` = -100.0f (Draw Depth of GUI elements)  
+   - `Primitive` = -75.0f (Default Primitive draw depth)  
+   - `TerrainBackground` = 50.0f (Draw Depth of Terrain Background layer)  
    - `Background` = 100.0f (Draw Depth of Background layer)
 
-- Added scaling capability to Bitmap primitives.
+- Added scaling capability to Bitmap primitives.  
 	New draw bindings with argument for scale are:
 	```
 	PrimitiveMan:DrawBitmapPrimitive(pos, moSprite, rotAngle, frame, scale)
@@ -150,17 +152,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Improved navigation, making running and fast walkpaths much more consistent.
 
-- Increased fog-of-war resolution in all vanilla activities, and conquest, from 20x20 to 4x4.
-	The Ronin Scrambler, the basic scanner, and `SceneMan:CastUnseenRay` have been changed to accomodate fog-of-war resolutions as fine as 1x1 and as coarse as 20x20.
+- Increased fog-of-war resolution in all vanilla activities, and conquest, from 20x20 to 4x4.  
+	The Ronin Scrambler, the basic scanner, and `SceneMan:CastUnseenRay` have been changed to accomodate fog-of-war resolutions as fine as 1x1 and as coarse as 20x20.  
 	The fog-of-war revealing code is now multithreaded to increase performance.
 
-- Save files are now compressed and stored in a single file, instead of a directory.
-	Savefiles have the extension `.ccsave`, but their underlying format is really just a `.zip` file. This can be opened and modified as before with any zip file viewer.
+- Save files are now compressed and stored in a single file, instead of a directory.  
+	Savefiles have the extension `.ccsave`, but their underlying format is really just a `.zip` file. This can be opened and modified as before with any zip file viewer.  
 	These savefiles can be safely renamed and moved without breaking the savegame, unlike before.
 
 - New GPU Renderer using now OpenGL + Raylib, dramatically improving draw performance. Draw now takes a negligible amount of time.
 
-- All vanilla scenario activities have had their settings polished, respecting settings which make sense and disabling settings which don't.
+- All vanilla scenario activities have had their settings polished, respecting settings which make sense and disabling settings which don't.  
 	You can now have fog of war in the test scene, and can no longer require path to orbit in Zero-G Diggers-Only One Man Army.
 
 - The "Clear" Preset button in the Buy Menu now clears the currently selected loadout, instead of the last one in the list.
@@ -173,17 +175,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - MOs now only play the BurstSound of the first Wound they receive in a frame, which not only solves audio spam during e.g. explosions but also preserves intended audio when firing guns with a high ParticleCount at them.
 
-- Changed how Get and SetLimbPathSpeed/PushForce work for `AHuman` and `ACrab`. The functions are as following:
-	`GetLimbPathSpeed` has been renamed to `GetLimbPathTravelSpeed`.
-	`SetLimbPathSpeed` has been renamed to `SetLimbPathTravelSpeed`.
-	`GetLimbPathTravelSpeed(Actor.MovementState)` returns the FG/left side (for crabs) limb path travel speed for that specific movement state, instead of being hardcoded to walking only.
-	`SetLimbPathTravelSpeed(Actor.MovementState, float newValue)` sets the travel speed for all layers and sides of any particular movement state's limb paths, instead of being hardcoded to walking only.
-	`GetLimbPathPushForce(Actor.MovementState)` returns the FG/left side (for crabs) limb path push force for that specific movement state, instead of being hardcoded to walking only.
+- Changed how Get and SetLimbPathSpeed/PushForce work for `AHuman` and `ACrab`. The functions are as following:  
+	`GetLimbPathSpeed` has been renamed to `GetLimbPathTravelSpeed`.  
+	`SetLimbPathSpeed` has been renamed to `SetLimbPathTravelSpeed`.  
+	`GetLimbPathTravelSpeed(Actor.MovementState)` returns the FG/left side (for crabs) limb path travel speed for that specific movement state, instead of being hardcoded to walking only.  
+	`SetLimbPathTravelSpeed(Actor.MovementState, float newValue)` sets the travel speed for all layers and sides of any particular movement state's limb paths, instead of being hardcoded to walking only.  
+	`GetLimbPathPushForce(Actor.MovementState)` returns the FG/left side (for crabs) limb path push force for that specific movement state, instead of being hardcoded to walking only.  
 	`SetLimbPathPushForce(Actor.MovementState, float newValue)` sets the push force for all layers and sides of any particular movement state's limb paths, instead of being hardcoded to walking only.
 	
 - The `LimbPath` property `NormalTravelSpeed` has been renamed to just `TravelSpeed`.
 
-- `GameActivity` INI properties `TeamNTech` values switched to lazy eval, allowing them to be validated once all modules are loaded.
+- `GameActivity` INI properties `TeamNTech` values switched to lazy eval, allowing them to be validated once all modules are loaded.  
 	As well, the scenario menu activity configuration screen now respects defaults set in INI, where possible.
 
 - Internal GUI element `ComboBox` no longer displays dropdown combobutton when disabled, to communicate visually that it's setting is not modifiable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixed an issue where the buy menu GUI could ignore mouse hover events until you clicked to reset the focus.
 
+- Fixed an issue where if the first objects in the buy cart are items instead of an actor, they would be added to the first actor's inventory- even if it was an actor without an inventory (i.e a crab)
+
 </details>
 
 <details><summary><b>Removed</b></summary>

--- a/Source/Activities/GameActivity.cpp
+++ b/Source/Activities/GameActivity.cpp
@@ -542,12 +542,10 @@ bool GameActivity::CreateDelivery(int player, int mode, Vector& waypoint, Actor*
 				totalCost = pDeliveryCraft->GetGoldValue(nativeModule, foreignCostMult, nativeCostMult);
 		}
 
-		// Go through the list of things ordered, and give any actors all the items that is present after them,
-		// until the next actor. Also, the first actor gets all stuff in the list above him.
-		MovableObject* pInventoryObject = 0;
-		Actor* pPassenger = 0;
-		Actor* pLastPassenger = 0;
-		std::list<MovableObject*> cargoItems;
+		// Go through the list of things ordered, and give any actors all the items that is present after them, until the next actor.
+		MovableObject* pInventoryObject = nullptr;
+		Actor* pPassenger = nullptr;
+		Actor* pLastPassenger = nullptr;
 
 		for (std::list<const SceneObject*>::iterator itr = purchaseList.begin(); itr != purchaseList.end(); ++itr) {
 			bool purchaseItem = true;
@@ -568,64 +566,35 @@ bool GameActivity::CreateDelivery(int player, int mode, Vector& waypoint, Actor*
 			if (purchaseItem) {
 				// Make copy of the preset instance in the list
 				pInventoryObject = dynamic_cast<MovableObject*>((*itr)->Clone());
-				// See if it's actually a passenger, as opposed to a regular item
+
+				if (pPassenger) {
+					pLastPassenger = pPassenger;
+				}
+
 				pPassenger = dynamic_cast<Actor*>(pInventoryObject);
+
 				// If it's an actor, then set its team and add it to the Craft's inventory!
 				if (pPassenger) {
-					if (dynamic_cast<AHuman*>(pPassenger)) {
-						// If this is the first passenger, then give him all the shit found in the list before him
-						if (!pLastPassenger) {
-							for (std::list<MovableObject*>::iterator iItr = cargoItems.begin(); iItr != cargoItems.end(); ++iItr)
-								pPassenger->AddInventoryItem(*iItr);
-						}
-						// This isn't the first passenger, so give the previous guy all the stuff that was found since processing him
-						else {
-							for (std::list<MovableObject*>::iterator iItr = cargoItems.begin(); iItr != cargoItems.end(); ++iItr)
-								pLastPassenger->AddInventoryItem(*iItr);
-						}
-
-						// Now set the current passenger as the 'last passenger' so he'll eventually get everything found after him.
-						pLastPassenger = pPassenger;
-					} else if (pLastPassenger) {
-						for (MovableObject* cargoItem: cargoItems) {
-							pLastPassenger->AddInventoryItem(cargoItem);
-						}
-						pLastPassenger = nullptr;
-					}
-					// Clear out the temporary cargo list since we've assign all the stuff in it to a passenger
-					cargoItems.clear();
 					// Set the team etc for the current passenger and stuff him into the craft
 					pPassenger->SetTeam(team);
 					pPassenger->SetControllerMode(Controller::CIM_AI);
 					pPassenger->SetAIMode((Actor::AIMode)mode);
 
-					if (pTargetMO != NULL) {
-						Actor* pTarget = dynamic_cast<Actor*>(pTargetMO);
-						if (pTarget)
-							pPassenger->AddAIMOWaypoint(pTarget);
+					if (Actor* pTarget = dynamic_cast<Actor*>(pTargetMO)) {
+						pPassenger->AddAIMOWaypoint(pTarget);
 					} else if (waypoint.m_X > 0 && waypoint.m_Y > 0) {
 						pPassenger->AddAISceneWaypoint(waypoint);
 					}
 
 					pDeliveryCraft->AddInventoryItem(pPassenger);
+				} else if (dynamic_cast<AHuman*>(pLastPassenger)) {
+					// Add ourselves to the last passenger's inventory
+					pLastPassenger->AddInventoryItem(pInventoryObject);
+				} else {
+					// No valid AHuman actor before us, just add ourself to the craft inventory
+					pDeliveryCraft->AddInventoryItem(pInventoryObject);
 				}
-				// If not, then add it to the temp list of items which will be added to the last passenger's inventory
-				else
-					cargoItems.push_back(pInventoryObject);
 			}
-		}
-
-		pPassenger = 0;
-
-		// If there was a last passenger and things after him, stuff all the items into his inventory
-		if (pLastPassenger) {
-			for (std::list<MovableObject*>::iterator iItr = cargoItems.begin(); iItr != cargoItems.end(); ++iItr)
-				pLastPassenger->AddInventoryItem(*iItr);
-		}
-		// Otherwise, stuff it all stuff directly into the craft instead
-		else {
-			for (std::list<MovableObject*>::iterator iItr = cargoItems.begin(); iItr != cargoItems.end(); ++iItr)
-				pDeliveryCraft->AddInventoryItem(*iItr);
 		}
 
 		float spawnY = 0.0f;


### PR DESCRIPTION
Fixed issue when first object in the buy cart is a non-actor, it would be added to the first actor's inventory (even if it was an actor without an inventory, i.e a crab).