### PR TITLE
Fix use after free with script timing in LuaMan.cpp

### DIFF
--- a/Source/Managers/LuaMan.cpp
+++ b/Source/Managers/LuaMan.cpp
@@ -614,8 +614,17 @@ int LuaStateWrapper::RunScriptFunctionObject(const LuabindObjectWrapper* functio
 			functionObjectArgument->GetLuabindObject()->push(m_State);
 		}
 	}
-
 	const std::string& path = functionObject->GetFilePath();
+
+	// Function object may be deleted during the Lua call, making `path` above invalid.
+	// Find and store the script timings entry now and write to it afterward.
+	PerformanceMan::ScriptTiming* timing = NULL;
+
+	// only track time in non-MT scripts, for now
+	if (&g_LuaMan.GetMasterScriptState() == this) {
+		timing = &m_ScriptTimings[path];
+	}
+
 	std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 	{
 		ZoneScoped;
@@ -631,10 +640,9 @@ int LuaStateWrapper::RunScriptFunctionObject(const LuabindObjectWrapper* functio
 	}
 	std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 
-	// only track time in non-MT scripts, for now
-	if (&g_LuaMan.GetMasterScriptState() == this) {
-		m_ScriptTimings[path].m_Time += std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-		m_ScriptTimings[path].m_CallCount++;
+	if (timing != NULL) {
+		timing->m_Time += std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+		timing->m_CallCount++;
 	}
 
 	lua_pop(m_State, 1);

--- a/Source/Managers/LuaMan.cpp
+++ b/Source/Managers/LuaMan.cpp
@@ -618,7 +618,7 @@ int LuaStateWrapper::RunScriptFunctionObject(const LuabindObjectWrapper* functio
 
 	// Function object may be deleted during the Lua call, making `path` above invalid.
 	// Find and store the script timings entry now and write to it afterward.
-	PerformanceMan::ScriptTiming* timing = NULL;
+	PerformanceMan::ScriptTiming* timing = nullptr;
 
 	// only track time in non-MT scripts, for now
 	if (&g_LuaMan.GetMasterScriptState() == this) {
@@ -640,7 +640,7 @@ int LuaStateWrapper::RunScriptFunctionObject(const LuabindObjectWrapper* functio
 	}
 	std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 
-	if (timing != NULL) {
+	if (timing) {
 		timing->m_Time += std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
 		timing->m_CallCount++;
 	}


### PR DESCRIPTION
In `RunScriptFunctionObject`, script timing is calculated before/after running the script, then written into `PerformanceMan::m_ScriptTimings`  table based on the path to the script. This introduces a use-after-free error and likely crashing if the script in question deallocates the function object, like Combat Shield's "Detach" pie menu option deleting itself: https://github.com/cortex-command-community/Cortex-Command-Community-Project/issues/219

My fix here is to get the table entry *before* running the script, store a pointer to it in a variable, and then access it directly after running the script. This also removes the double lookup into the unordered_map.

In my testing, this fixes the issue entirely. I'm not knowledgeable on this codebase or on C++isms, I don't know what's the policy of the project on raw pointers, so if this doesn't fit, please feel free to disregard this and implement an equivalent kind of a solution in proper language etiquette instead lol

Fixes https://github.com/cortex-command-community/Cortex-Command-Community-Project/issues/219