### PR TITLE
SetHoveredPieSlice - unset m_ActiveSubPieMenu if set

### DIFF
--- a/Source/Entities/PieMenu.cpp
+++ b/Source/Entities/PieMenu.cpp
@@ -1212,6 +1212,11 @@ bool PieMenu::SetHoveredPieSlice(const PieSlice* pieSliceToSelect, bool moveCurs
 		return false;
 	}
 
+	if (m_ActiveSubPieMenu) {
+		m_ActiveSubPieMenu->SetEnabled(false, false);
+		m_ActiveSubPieMenu = nullptr;
+	}
+
 	m_HoveredPieSlice = pieSliceToSelect;
 	m_SubPieMenuHoverOpenTimer.Reset();
 	m_BGBitmapNeedsRedrawing = true;


### PR DESCRIPTION
When a different (or null) pie slice is selected, the current subpiemenu is obviously not relevant. Don't set it.

This fixes a crash if the player goes into a subpiemenu, and, while holding pie menu button, switches actors (hence setting hovered pie slice to null, but leaving m_ActiveSubPieMenu set), then switches back, and tries to open pie menu again, causing a crash in `Update` on line 568.

Stack trace on crash:

<details>

```
Stack trace (most recent call last):
#10   Object "", at 0xffffffffffffffff, in
#9    Object "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/CortexCommand", at 0x55916038fbb4, in _start
#8    Object "/usr/lib/libc.so.6", at 0x7f72bcc27c4a, in __libc_start_main
#7    Object "/usr/lib/libc.so.6", at 0x7f72bcc27b8a, in __libc_init_first
#6    Source "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/../Source/Main.cpp", line 468, in main [0x559160392589]
        465: 			RunMenuLoop();
        466: 		}
        467:
      > 468: 		RunGameLoop();
        469: 	}
        470:
        471: 	g_ThreadMan.GetPriorityThreadPool().wait_for_tasks();
#5    Source "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/../Source/Main.cpp", line 354, in RunGameLoop() [0x55916039197b]
        351: 			}
        352:
        353: 			g_LuaMan.ClearScriptTimings();
      > 354: 			g_MovableMan.Update();
        355: 			g_PerformanceMan.UpdateSortedScriptTimings(g_LuaMan.GetScriptTimings());
        356:
        357: 			g_AudioMan.Update();
#4    Source "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/../Source/Managers/MovableMan.cpp", line 1405, in RTE::MovableMan::Update() [0x5591607fc456]
       1403: 			g_PerformanceMan.StartPerformanceMeasurement(PerformanceMan::ActorsUpdate);
       1404: 			for (Actor* actor: m_Actors) {
      >1405: 				actor->Update();
       1406:
       1407: 				g_PerformanceMan.StartPerformanceMeasurement(PerformanceMan::ScriptsUpdate);
       1408: 				actor->UpdateScripts();
#3    Source "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/../Source/Entities/AHuman.cpp", line 2436, in RTE::AHuman::Update() [0x559160497f2c]
       2434: 	float rot = m_Rotation.GetRadAngle(); // eugh, for backwards compat to be the same behaviour as with multithreaded AI
       2435:
      >2436: 	Actor::Update();
       2437:
       2438: 	////////////////////////////////////
       2439: 	// Update viewpoint
#2    Source "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/../Source/Entities/Actor.cpp", line 1115, in RTE::Actor::Update() [0x55916045af0a]
       1112: 	// Hit Body update and handling
       1113: 	MOSRotating::Update();
       1114:
      >1115: 	m_PieMenu->Update();
       1116:
       1117: 	// Update the viewpoint to be at least what the position is
       1118: 	m_ViewPoint = m_Pos;
#1    Source "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/../Source/Entities/PieMenu.cpp", line 568, in RTE::PieMenu::Update() [0x55916057b889]
        565: 			bool skipInputBecauseActiveSubPieMenuWasJustDisabled = false;
        566:
        567: 			if (m_ActiveSubPieMenu) {
      > 568: 				m_CursorAngle = m_HoveredPieSlice->GetMidAngle() + GetRotAngle();
        569: 				m_CursorInVisiblePosition = false;
        570: 				m_HoverTimer.Reset();
#0    Source "/media/ext_hdd/nobackup/architector4/Downloads/Cortex-Command-Community-Project/builddebug/../Source/Entities/PieSlice.h", line 206, in RTE::PieSlice::GetMidAngle() const [0x559160582e78]
        204: 		/// Gets the mid angle this PieSlice's area is set to be at in its pie menu.
        205: 		/// @return The mid angle of this PieSlice's area.
      > 206: 		float GetMidAngle() const { return m_MidAngle; }
        207:
        208: 		/// Sets the mid angle this PieSlice's area should be at in its pie menu.
        209: 		/// @param midAngle The mid angle to set for the PieSlice's area.
Segmentation fault (Address not mapped to object [0x108])
Segmentation fault         prime-run builddebug/CortexCommand
```

</details>

How the crash looks like:

https://github.com/user-attachments/assets/7b1aa75c-6288-4f1e-a120-9222995801b6

Does not happen with this applied.