### PR TITLE
Actor.h - include PathFinder.h, fix compile fail introduced in PR #224

### DIFF
--- a/Source/Entities/Actor.h
+++ b/Source/Entities/Actor.h
@@ -6,6 +6,7 @@
 /// http://www.datarealms.com
 /// Inclusions of header files
 #include "MOSRotating.h"
+#include "PathFinder.h"
 
 namespace RTE {
 


### PR DESCRIPTION
My bad! I forgot to put the include in the commit. Should compile fine with it not forgotten lmao

https://github.com/cortex-command-community/Cortex-Command-Community-Project/pull/224