### PR TITLE
LimbPath.cpp - fix debug line drawing

### DIFF
--- a/Source/Entities/LimbPath.cpp
+++ b/Source/Entities/LimbPath.cpp
@@ -517,8 +517,8 @@ void LimbPath::Draw(BITMAP* pTargetBitmap,
 	for (std::deque<Vector>::const_iterator itr = m_Segments.begin(); itr != m_Segments.end(); ++itr) {
 		nextPoint += *itr;
 
-		Vector prevWorldPosition = m_JointPos + (RotatePoint(prevPoint * GetTotalScaleMultiplier()));
-		Vector nextWorldPosition = m_JointPos + (RotatePoint(nextPoint * GetTotalScaleMultiplier()));
+		Vector prevWorldPosition = m_JointPos + (RotatePoint(prevPoint * GetTotalScaleMultiplier()) - targetPos);
+		Vector nextWorldPosition = m_JointPos + (RotatePoint(nextPoint * GetTotalScaleMultiplier()) - targetPos);
 		line(pTargetBitmap, prevWorldPosition.m_X, prevWorldPosition.m_Y, nextWorldPosition.m_X, nextWorldPosition.m_Y, color);
 
 		Vector min(std::min(prevWorldPosition.m_X, nextWorldPosition.m_X), std::min(prevWorldPosition.m_Y, nextWorldPosition.m_Y));
@@ -528,3 +528,4 @@ void LimbPath::Draw(BITMAP* pTargetBitmap,
 		prevPoint += *itr;
 	}
 }
+


### PR DESCRIPTION
Debug draws in LimbPath.cpp don't take use the `targetPos` function argument and end up rendering wrong.

If only there was a compiler setting or something to find unused function arguments... :v

Before this patch:

https://github.com/user-attachments/assets/1853946c-d057-4a26-b0b1-d557635cd496

After this patch:

https://github.com/user-attachments/assets/7867325d-91e3-4701-8f8e-ef859734a566

The importance of this is probably "who cares", but at at least the squiggles aren't going to be all over the place with full debug mode now lmao