### PR TITLE
meson.build - enable debug compatible optimizations in debug modes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -68,8 +68,10 @@ if compiler.get_argument_syntax()== 'gcc' # used for gcc compatible compilers
     if debug_type == 'release'
       preprocessor_flags += ['-DRELEASE_BUILD'] # enable minimal debug features
     elif debug_type == 'minimal'
+      extra_args += ['-Og'] # debug-compatible optimizations
       preprocessor_flags += ['-DMIN_DEBUG_BUILD', '-DDEBUGMODE'] # enable some debug features
     elif debug_type == 'full'
+      extra_args += ['-Og'] # debug-compatible optimizations
       preprocessor_flags += ['-DDEBUG_BUILD', '-DDEBUGMODE'] # enable all debug features; may slow down game
     endif
   else


### PR DESCRIPTION
According to `man gcc`:

> Optimize debugging experience. -Og should be the optimization level of choice for the standard edit-compile-debug cycle, offering a reasonable level of optimization while maintaining fast compilation and a good debugging experience. It is a better choice than -O0 for producing debuggable code because some compiler passes that collect debug information are disabled at -O0.

TLDR: it's a no-brainer to enable for debug builds. I'm running the game in debug nowadays, and using this genuinely just makes it run way faster lol