### PR TITLE
fix CI for Windows

### DIFF
--- a/Source/Entities/Actor.h
+++ b/Source/Entities/Actor.h
@@ -8,6 +8,8 @@
 #include "MOSRotating.h"
 #include "PathFinder.h"
 
+#include <array>
+
 namespace RTE {
 
 #pragma region Global Macro Definitions

--- a/Source/Entities/PieMenu.cpp
+++ b/Source/Entities/PieMenu.cpp
@@ -14,6 +14,8 @@
 #include "GUIFont.h"
 #include "AllegroBitmap.h"
 
+#include <array>
+
 using namespace RTE;
 
 ConcreteClassInfo(PieMenu, Entity, 20);

--- a/Source/Entities/TerrainObject.cpp
+++ b/Source/Entities/TerrainObject.cpp
@@ -4,6 +4,8 @@
 #include "Draw.h"
 #include "FrameMan.h"
 
+#include <array>
+
 using namespace RTE;
 
 ConcreteClassInfo(TerrainObject, SceneObject, 0);

--- a/Source/Managers/ActivityMan.cpp
+++ b/Source/Managers/ActivityMan.cpp
@@ -33,6 +33,7 @@
 #include "SDL3/SDL_surface.h"
 #include <SDL3_image/SDL_image.h>
 
+#include <array>
 #include <execution>
 
 using namespace RTE;

--- a/Source/Managers/AudioMan.cpp
+++ b/Source/Managers/AudioMan.cpp
@@ -12,6 +12,7 @@
 #include "WindowMan.h"
 #include "SoundSet.h"
 
+#include <array>
 #include <cstring>
 
 using namespace RTE;

--- a/Source/Managers/FrameMan.cpp
+++ b/Source/Managers/FrameMan.cpp
@@ -32,6 +32,8 @@
 #include "tracy/TracyOpenGL.hpp"
 #include <SDL3_image/SDL_image.h>
 
+#include <array>
+
 using namespace RTE;
 
 void BitmapDeleter::operator()(BITMAP* bitmap) const { destroy_bitmap(bitmap); }

--- a/Source/Managers/LuaMan.h
+++ b/Source/Managers/LuaMan.h
@@ -7,6 +7,8 @@
 
 #include "BS_thread_pool.hpp"
 
+#include <array>
+
 #define g_LuaMan LuaMan::Instance()
 
 struct lua_State;

--- a/Source/Managers/PerformanceMan.cpp
+++ b/Source/Managers/PerformanceMan.cpp
@@ -6,6 +6,8 @@
 #include "GUI.h"
 #include "AllegroBitmap.h"
 
+#include <array>
+
 using namespace RTE;
 
 const std::array<std::string, PerformanceMan::PerformanceCounters::PerfCounterCount> PerformanceMan::m_PerfCounterNames = {"Total", "Act AI", "Act Travel", "Act Update", "Prt Travel", "Prt Update", "Activity", "Scripts"};

--- a/Source/Managers/PostProcessMan.cpp
+++ b/Source/Managers/PostProcessMan.cpp
@@ -20,6 +20,8 @@
 #include "tracy/Tracy.hpp"
 #include "tracy/TracyOpenGL.hpp"
 
+#include <array>
+
 using namespace RTE;
 
 PostProcessMan::PostProcessMan() {

--- a/Source/Managers/PresetMan.cpp
+++ b/Source/Managers/PresetMan.cpp
@@ -18,6 +18,8 @@
 #include "SettingsMan.h"
 #include "System.h"
 
+#include <array>
+
 using namespace RTE;
 
 const std::array<std::string, 10> PresetMan::c_OfficialModules = {"Base.rte", "Coalition.rte", "Imperatus.rte", "Techion.rte", "Dummy.rte", "Ronin.rte", "Browncoats.rte", "Uzira.rte", "MuIlaak.rte", "Missions.rte"};

--- a/Source/Managers/UInputMan.cpp
+++ b/Source/Managers/UInputMan.cpp
@@ -14,6 +14,7 @@
 #include "System.h"
 
 #include <SDL3/SDL.h>
+#include <array>
 #include <string>
 #include <unordered_map>
 

--- a/Source/Menus/MainMenuGUI.h
+++ b/Source/Menus/MainMenuGUI.h
@@ -6,6 +6,8 @@
 #include "SettingsGUI.h"
 #include "ModManagerGUI.h"
 
+#include <array>
+
 namespace RTE {
 
 	class AllegroScreen;

--- a/Source/Menus/SettingsInputMappingGUI.cpp
+++ b/Source/Menus/SettingsInputMappingGUI.cpp
@@ -8,6 +8,8 @@
 #include "GUIScrollbar.h"
 #include "GUILabel.h"
 
+#include <array>
+
 using namespace RTE;
 
 std::array<InputElements, 7> SettingsInputMappingGUI::m_InputElementsUsedByMouse = {InputElements::INPUT_FIRE, InputElements::INPUT_PIEMENU_ANALOG, InputElements::INPUT_AIM, InputElements::INPUT_AIM_UP, InputElements::INPUT_AIM_DOWN, InputElements::INPUT_AIM_LEFT, InputElements::INPUT_AIM_RIGHT};

--- a/Source/Renderer/GraphicalPrimitive.cpp
+++ b/Source/Renderer/GraphicalPrimitive.cpp
@@ -9,6 +9,8 @@
 #include "AllegroBitmap.h"
 
 #include "Draw.h"
+
+#include <array>
 #include <cmath>
 
 using namespace RTE;

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -6,6 +6,8 @@
 #include "raylib/raylib.h"
 #include "raylib/rlgl.h"
 
+#include <array>
+
 namespace RTE {
 	class Shader: public Entity {
 	public:

--- a/Source/System/ContentFile.cpp
+++ b/Source/System/ContentFile.cpp
@@ -12,6 +12,7 @@
 #include "fmod/fmod_errors.h"
 #include <SDL3_image/SDL_image.h>
 
+#include <array>
 #include <cstring>
 
 using namespace RTE;

--- a/Source/System/Controller.cpp
+++ b/Source/System/Controller.cpp
@@ -6,6 +6,8 @@
 #include "Actor.h"
 #include "PieMenu.h"
 
+#include <array>
+
 using namespace RTE;
 
 void Controller::Clear() {

--- a/Source/System/Entity.h
+++ b/Source/System/Entity.h
@@ -3,6 +3,7 @@
 #include "Serializable.h"
 #include "RTEError.h"
 
+#include <mutex>
 #include <list>
 #include <unordered_set>
 

--- a/Source/System/PathFinder.cpp
+++ b/Source/System/PathFinder.cpp
@@ -8,6 +8,7 @@
 
 #include "tracy/Tracy.hpp"
 
+#include <array>
 #include <execution>
 
 using namespace RTE;

--- a/Source/System/PathFinder.h
+++ b/Source/System/PathFinder.h
@@ -3,6 +3,7 @@
 #include "Box.h"
 #include "System/MicroPather/micropather.h"
 
+#include <array>
 #include <atomic>
 #include <list>
 #include <memory>

--- a/Source/System/PieQuadrant.cpp
+++ b/Source/System/PieQuadrant.cpp
@@ -2,6 +2,8 @@
 
 #include "RTETools.h"
 
+#include <array>
+
 using namespace RTE;
 
 void PieQuadrant::Clear() {

--- a/Source/System/SpatialPartitionGrid.h
+++ b/Source/System/SpatialPartitionGrid.h
@@ -7,6 +7,8 @@
 
 #include "tsl/hopscotch_set.h"
 
+#include <array>
+
 namespace RTE {
 
 	class Box;


### PR DESCRIPTION
File `Entity.h` uses `std::mutex` but never actually does `#include <mutex>`.

As far as I can tell, it just happened by chance that:
- `# include <bits/std_mutex.h>` is written in file `/usr/include/c++/15.2.1/bits/atomic_wait.h` from the GNU C++ library implementation
- Which is included by `/usr/include/c++/15.2.1/bits/atomic_base.h`
- Which is included by `/usr/include/c++/15.2.1/bits/shared_ptr_atomic.h`
- Which is included by `/usr/include/c++/15.2.1/memory`
- Which is included as `<memory>` by `Source/System/Reader.h`
- Which is included by `Source/System/Serializable.h`
- Which is included by `Source/System/Entity.h`

...But of course, I assume GNU C++ library is not used by Microsoft's compiler, and files that they do have likely don't end up including mutex.

So, just, include the mutex where it's used.