### PR TITLE
Fix some Lua scripts - OnDestroy -> Destroy

### DIFF
--- a/Data/Browncoats.rte/Devices/Weapons/Heatlance/Heatlance.lua
+++ b/Data/Browncoats.rte/Devices/Weapons/Heatlance/Heatlance.lua
@@ -126,7 +126,7 @@ function ThreadedUpdate(self)
 	end
 end
 
-function OnDestroy(self)
+function Destroy(self)
 	self.flameSwingLoopSound.Volume = 0;
 	self.plumeLoopSound.Volume = 0;
 end

--- a/Data/Browncoats.rte/Scenes/Objects/Breakables/RefineryConsole/RefineryConsole.lua
+++ b/Data/Browncoats.rte/Scenes/Objects/Breakables/RefineryConsole/RefineryConsole.lua
@@ -6,7 +6,7 @@ function Create(self)
 	self.loopSound:Play(self.Pos);
 end
 
-function OnDestroy(self)
+function Destroy(self)
 
 	self.Activity:SendMessage("RefineryAssault_RefineryConsoleBroken");
 

--- a/Data/Browncoats.rte/Scenes/Objects/Breakables/RefineryDrill/RefineryDrill.lua
+++ b/Data/Browncoats.rte/Scenes/Objects/Breakables/RefineryDrill/RefineryDrill.lua
@@ -33,6 +33,6 @@ function ThreadedUpdate(self)
 	end
 end
 
-function OnDestroy(self)
+function Destroy(self)
 	self.loopSound:Stop(-1);
 end

--- a/Data/Browncoats.rte/Scenes/Objects/Breakables/RefineryGenerator/RefineryGenerator.lua
+++ b/Data/Browncoats.rte/Scenes/Objects/Breakables/RefineryGenerator/RefineryGenerator.lua
@@ -15,6 +15,6 @@ function ThreadedUpdate(self)
 	end
 end
 
-function OnDestroy(self)
+function Destroy(self)
 	self.Activity:SendMessage("RefineryAssault_RefineryGeneratorBroken");
 end


### PR DESCRIPTION
Fixes *current instances* of https://github.com/cortex-command-community/Cortex-Command-Community-Project/issues/221

But ideally, there should probably be some kind of instrumentation that creates warnings about Lua functions that are defined but not used by anything to prevent issues like this.