### PR TITLE
gitignore - also ignore *.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ luac.out
 *.x86_64
 *.hex
 *.bat
+*.sh
 CortexCommand
 CortexCommand_debug
 CortexCommand.AppImage


### PR DESCRIPTION
Shell files are basically the Linux equivalent of WIndows's *.bat files, which are already ignored. This is handy for me because I like using scripts for things lol