### PR TITLE
Make Constructor try to find pixels to dig up to 5 times

### DIFF
--- a/Data/Base.rte/Devices/Tools/Constructor/Constructor.lua
+++ b/Data/Base.rte/Devices/Tools/Constructor/Constructor.lua
@@ -326,11 +326,19 @@ function Update(self)
 					end
 				else
 					for i = 1, self.RoundsFired do
-						local trace = Vector(self.digLength, 0):RadRotate(angle + RangeRand(-1, 1) * self.spreadRange);
-						local digPos = ConstructorTerrainRay(self.MuzzlePos, trace, 0);
 
-						if SceneMan:GetTerrMatter(digPos.X, digPos.Y) ~= rte.airID then
+						local trace, digPos, diggingAir
+						for _ = 1, 5 do
+							-- Try up to 5 times to find a pixel to dig
+							trace = Vector(self.digLength, 0):RadRotate(angle + RangeRand(-1, 1) * self.spreadRange);
+							digPos = ConstructorTerrainRay(self.MuzzlePos, trace, 0);
+							diggingAir = SceneMan:GetTerrMatter(digPos.X, digPos.Y) == rte.airID
+							if not diggingAir then
+								break
+							end
+						end
 
+						if not diggingAir then
 							local digWeightTotal = 0;
 							local totalVel = Vector();
 							local found = 0;


### PR DESCRIPTION
Fixes yet another pet peeve of mine. When digging ground with the constructor, it way too often leaves singular pixels all over the place that you can't see but then then get randomly stuck on when going around dug terrain.

With this patch, if it fails to find a pixel to dig, it tries to find one again up to 4 more times instead of immediately giving up.

This doesn't make the Constructor stronger at all; in normal digging, it will still cast only a single digging ray. At best it makes it slightly more reliable when digging sparse terrain.

I guess this makes it a little more equivalent to digging tools, which typically knock off singular outstanding pixels by spraying most of what they dig all over the place.