### PR TITLE
cppcheck lints - change a lot of method params to use const ref, etc etc

### DIFF
--- a/Source/Activities/AssemblyEditor.cpp
+++ b/Source/Activities/AssemblyEditor.cpp
@@ -377,7 +377,7 @@ void AssemblyEditor::Draw(BITMAP* pTargetBitmap, const Vector& targetPos) {
 	EditorActivity::Draw(pTargetBitmap, targetPos);
 }
 
-BunkerAssembly* AssemblyEditor::BuildAssembly(std::string saveAsName) {
+BunkerAssembly* AssemblyEditor::BuildAssembly(const std::string& saveAsName) {
 	// Create new bunker assembly to save
 	BunkerAssembly* pBA = new BunkerAssembly();
 	pBA->Create(m_pEditorGUI->GetCurrentAssemblyScheme());

--- a/Source/Activities/AssemblyEditor.h
+++ b/Source/Activities/AssemblyEditor.h
@@ -107,7 +107,7 @@ namespace RTE {
 		/// it's pointer. Owhership IS transfered.
 		/// @param saveAsName New assembly name.
 		/// @return Built BunkerAssembly
-		BunkerAssembly* BuildAssembly(std::string saveAsName);
+		BunkerAssembly* BuildAssembly(const std::string& saveAsName);
 
 		/// Saves the current BunkerAssembly to an appropriate ini file, and asks user if they want to overwrite first if a BunkerAssembly of this name exists.
 		/// @param saveAsName The name of the new BunkerAssembly to be saved.

--- a/Source/Activities/GAScripted.h
+++ b/Source/Activities/GAScripted.h
@@ -49,8 +49,8 @@ namespace RTE {
 		/// @return An error return value signaling sucess or any particular failure.
 		/// Anything below 0 is an error signal.
 		int Create(std::string scriptPath, std::string scriptClassName) {
-			m_ScriptPath = scriptPath;
-			m_LuaClassName = scriptClassName;
+			m_ScriptPath = std::move(scriptPath);
+			m_LuaClassName = std::move(scriptClassName);
 			return Create();
 		};
 

--- a/Source/Activities/GATutorial.cpp
+++ b/Source/Activities/GATutorial.cpp
@@ -35,10 +35,11 @@ GATutorial::~GATutorial() {
 	Destroy(true);
 }
 
-GATutorial::TutStep::TutStep(std::string text, int stepDuration, std::string screensPath, int frameCount, int frameDuration) {
-	m_Text = text;
-	m_Duration = stepDuration;
-	m_FrameDuration = frameDuration;
+GATutorial::TutStep::TutStep(std::string text, int stepDuration, const std::string& screensPath, int frameCount, int frameDuration) :
+	m_Text(std::move(text)),
+	m_Duration(stepDuration),
+	m_FrameDuration(frameDuration)
+	{
 
 	if (!screensPath.empty()) {
 		ContentFile(screensPath.c_str()).GetAsAnimation(m_pScreens, frameCount);
@@ -677,7 +678,7 @@ void GATutorial::DrawGUI(BITMAP* pTargetBitmap, const Vector& targetPos, int whi
 			int timePhase = (int)m_AreaTimer.GetElapsedRealTimeMS() % 1200;
 			revealText = revealText + (timePhase > 900 ? "..." : (timePhase > 600 ? ".. " : (timePhase > 300 ? ".  " : "   ")));
 		}
-		g_FrameMan.GetSmallFont()->DrawAligned(&pBitmapInt, screenTextPos.m_X, screenTextPos.m_Y, revealText.c_str(), GUIFont::Centre);
+		g_FrameMan.GetSmallFont()->DrawAligned(&pBitmapInt, screenTextPos.m_X, screenTextPos.m_Y, revealText, GUIFont::Centre);
 	}
 }
 

--- a/Source/Activities/GATutorial.h
+++ b/Source/Activities/GATutorial.h
@@ -150,7 +150,7 @@ namespace RTE {
 			// The duration of one frame
 			int m_FrameDuration;
 
-			TutStep(std::string text, int stepDuration, std::string screensPath = "", int frameCount = 1, int frameDuration = 250);
+			TutStep(std::string text, int stepDuration, const std::string& screensPath = "", int frameCount = 1, int frameDuration = 250);
 		};
 
 		// Member variables

--- a/Source/Activities/GameActivity.cpp
+++ b/Source/Activities/GameActivity.cpp
@@ -2481,7 +2481,7 @@ const std::string& GameActivity::GetNetworkPlayerName(int player) {
 		return m_NetworkPlayerNames[0];
 }
 
-void GameActivity::SetNetworkPlayerName(int player, const std::string& name) {
+void GameActivity::SetNetworkPlayerName(int player, std::string name) {
 	if (player >= Players::PlayerOne && player < Players::MaxPlayerCount)
 		m_NetworkPlayerNames[player] = std::move(name);
 }

--- a/Source/Activities/GameActivity.cpp
+++ b/Source/Activities/GameActivity.cpp
@@ -282,7 +282,7 @@ void GameActivity::Destroy(bool notInherited) {
 	Clear();
 }
 
-void GameActivity::SetTeamTech(int team, std::string tech) {
+void GameActivity::SetTeamTech(int team, const std::string& tech) {
 	if (team >= Teams::TeamOne && team < Teams::MaxTeamCount) {
 		if (tech == "-All-" || tech == "-Random-")
 			m_TeamTech[team] = tech;
@@ -388,7 +388,7 @@ void GameActivity::SwitchToPrevActor(int player, int team, Actor* pSkip) {
 	}
 }
 
-void GameActivity::AddObjectivePoint(std::string description, Vector objPos, int whichTeam, ObjectiveArrowDir arrowDir) {
+void GameActivity::AddObjectivePoint(const std::string& description, Vector objPos, int whichTeam, ObjectiveArrowDir arrowDir) {
 	m_Objectives.push_back(ObjectivePoint(description, objPos, whichTeam, arrowDir));
 }
 
@@ -468,7 +468,7 @@ int GameActivity::SetOverridePurchaseList(const Loadout* pLoadout, int player) {
 	return finalListCost;
 }
 
-int GameActivity::SetOverridePurchaseList(std::string loadoutName, int player) {
+int GameActivity::SetOverridePurchaseList(const std::string& loadoutName, int player) {
 	// Find out the native module of this player
 	int nativeModule = 0;
 	MetaPlayer* pMetaPlayer = g_MetaMan.GetMetaPlayerOfInGamePlayer(player);
@@ -664,7 +664,7 @@ void GameActivity::SetupPlayers() {
 
 int GameActivity::Start() {
 	// Set the split screen config before the Scene (and it SceneLayers, specifially) are loaded
-	int humanCount = GetHumanCount();
+	uint8_t humanCount = GetHumanCount();
 	// Depending on the resolution aspect ratio, split first horizontally (if wide screen)
 	if (((float)g_WindowMan.GetResX() / (float)g_WindowMan.GetResY()) >= 1.6)
 		g_FrameMan.ResetSplitScreens(humanCount > 1, humanCount > 2);
@@ -2474,14 +2474,14 @@ void GameActivity::ObjectivePoint::Draw(BITMAP* pTargetBitmap, BITMAP* pArrowBit
 	}
 }
 
-std::string& GameActivity::GetNetworkPlayerName(int player) {
+const std::string& GameActivity::GetNetworkPlayerName(int player) {
 	if (player >= Players::PlayerOne && player < Players::MaxPlayerCount)
 		return m_NetworkPlayerNames[player];
 	else
 		return m_NetworkPlayerNames[0];
 }
 
-void GameActivity::SetNetworkPlayerName(int player, std::string name) {
+void GameActivity::SetNetworkPlayerName(int player, const std::string& name) {
 	if (player >= Players::PlayerOne && player < Players::MaxPlayerCount)
-		m_NetworkPlayerNames[player] = name;
+		m_NetworkPlayerNames[player] = std::move(name);
 }

--- a/Source/Activities/GameActivity.h
+++ b/Source/Activities/GameActivity.h
@@ -238,7 +238,7 @@ namespace RTE {
 		/// @param objPos The very short description of what the objective is (three short words max)
 		/// @param whichTeam The absolute scene coordiante position of the objective. (default: Teams::TeamOne)
 		/// @param arrowDir The desired direction of the arrow when the point is on screen. (default: ARROWDOWN)
-		void AddObjectivePoint(std::string description, Vector objPos, int whichTeam = Teams::TeamOne, ObjectiveArrowDir arrowDir = ARROWDOWN);
+		void AddObjectivePoint(const std::string& description, Vector objPos, int whichTeam = Teams::TeamOne, ObjectiveArrowDir arrowDir = ARROWDOWN);
 
 		/// Sorts all objective points according to their positions on the Y axis.
 		void YSortObjectivePoints();
@@ -265,7 +265,7 @@ namespace RTE {
 		/// @param loadoutName The name of the Loadout preset to set the override purchase list to
 		/// represent.
 		/// @return The new total value of what's in the override purchase list.
-		int SetOverridePurchaseList(std::string loadoutName, int player);
+		int SetOverridePurchaseList(const std::string& loadoutName, int player);
 
 		/// Clears all items from a specific player's override purchase list.
 		/// @param m_PurchaseOverride[player].clear( Which player's override purchase list to clear.
@@ -352,7 +352,7 @@ namespace RTE {
 
 		/// Sets tech module name for specified team. Module must set must be loaded.
 		/// @param team Team to set module, module name, for example Dummy.rte
-		void SetTeamTech(int team, std::string tech);
+		void SetTeamTech(int team, const std::string& tech);
 
 		/// Indicates whether a specific team is assigned a CPU player in the current game.
 		/// @param team Which team index to check.
@@ -448,11 +448,11 @@ namespace RTE {
 		/// Returns network player name
 		/// @param player Player
 		/// @return Network player name
-		std::string& GetNetworkPlayerName(int player);
+		const std::string& GetNetworkPlayerName(int player);
 
 		/// Sets network player name
 		/// @param player Player number, player name
-		void SetNetworkPlayerName(int player, std::string name);
+		void SetNetworkPlayerName(int player, const std::string& name);
 
 		/// Protected member variable and method declarations
 	protected:
@@ -470,12 +470,13 @@ namespace RTE {
 				m_Team = Teams::NoTeam;
 				m_ArrowDir = ARROWDOWN;
 			}
-			ObjectivePoint(const std::string& desc, const Vector& pos, int team = -1, ObjectiveArrowDir arrowDir = ARROWDOWN) {
-				m_Description = desc;
-				m_ScenePos = pos;
-				m_Team = (Teams)team;
-				m_ArrowDir = arrowDir;
-			}
+
+			ObjectivePoint(std::string desc, const Vector& pos, int team = -1, ObjectiveArrowDir arrowDir = ARROWDOWN) :
+				m_Description(std::move(desc)),
+				m_ScenePos(pos),
+				m_Team((Teams)team),
+				m_ArrowDir(arrowDir)
+			{}
 
 			/// Simply draws this' arrow relative to a point on a bitmap.
 			/// @param pTargetBitmap A pointer to the BITMAP to draw on.

--- a/Source/Activities/GameActivity.h
+++ b/Source/Activities/GameActivity.h
@@ -452,7 +452,7 @@ namespace RTE {
 
 		/// Sets network player name
 		/// @param player Player number, player name
-		void SetNetworkPlayerName(int player, const std::string& name);
+		void SetNetworkPlayerName(int player, std::string name);
 
 		/// Protected member variable and method declarations
 	protected:

--- a/Source/Entities/AHuman.cpp
+++ b/Source/Entities/AHuman.cpp
@@ -686,7 +686,7 @@ bool AHuman::EquipFirearm(bool doEquip) {
 	return false;
 }
 
-bool AHuman::EquipDeviceInGroup(std::string group, bool doEquip) {
+bool AHuman::EquipDeviceInGroup(const std::string& group, bool doEquip) {
 	if (!(m_pFGArm && m_pFGArm->IsAttached())) {
 		return false;
 	}
@@ -748,7 +748,7 @@ bool AHuman::EquipDeviceInGroup(std::string group, bool doEquip) {
 	return false;
 }
 
-bool AHuman::EquipLoadedFirearmInGroup(std::string group, std::string excludeGroup, bool doEquip) {
+bool AHuman::EquipLoadedFirearmInGroup(const std::string& group, const std::string& excludeGroup, bool doEquip) {
 	if (!(m_pFGArm && m_pFGArm->IsAttached())) {
 		return false;
 	}

--- a/Source/Entities/AHuman.h
+++ b/Source/Entities/AHuman.h
@@ -243,7 +243,7 @@ namespace RTE {
 		/// @param doEquip Whether to actually equip any matching item found in the inventory, (default: true)
 		/// or just report that it's there or not.
 		/// @return Whether a firearm was successfully switched to, or already held.
-		bool EquipDeviceInGroup(std::string group, bool doEquip = true);
+		bool EquipDeviceInGroup(const std::string& group, bool doEquip = true);
 
 		/// Switches the currently held device (if any) to the first loaded HDFirearm
 		/// of the specified group in the inventory. If no such weapon is in the
@@ -253,7 +253,7 @@ namespace RTE {
 		/// @param doEquip Whether to actually equip any matching item found in the inventory, (default: true)
 		/// or just report that it's there or not.
 		/// @return Whether a firearm was successfully switched to, or already held.
-		bool EquipLoadedFirearmInGroup(std::string group, std::string exludeGroup, bool doEquip = true);
+		bool EquipLoadedFirearmInGroup(const std::string& group, const std::string& exludeGroup, bool doEquip = true);
 
 		/// Switches the equipped HeldDevice (if any) to the first found device with the specified preset name in the inventory.
 		/// If the equipped HeldDevice is of that module and preset name, nothing happens.

--- a/Source/Entities/Activity.cpp
+++ b/Source/Entities/Activity.cpp
@@ -467,8 +467,8 @@ void Activity::ClearPlayers(bool resetFunds) {
 	m_PlayerCount = m_TeamCount = 0;
 }
 
-int Activity::GetHumanCount() const {
-	int humans = 0;
+uint8_t Activity::GetHumanCount() const {
+	uint8_t humans = 0;
 	for (int player = Players::PlayerOne; player < Players::MaxPlayerCount; ++player) {
 		if (m_IsActive[player] && m_IsHuman[player]) {
 			humans++;

--- a/Source/Entities/Activity.h
+++ b/Source/Entities/Activity.h
@@ -129,7 +129,7 @@ namespace RTE {
 
 		/// Gets the user-friendly description of this Activity.
 		/// @return A string with the user-friendly description of this Activity.
-		std::string GetDescription() const { return m_Description; }
+		const std::string& GetDescription() const { return m_Description; }
 
 		/// Gets the max number of players supported by this Activity.
 		/// @return The max number of players supported by this Activity.
@@ -156,11 +156,11 @@ namespace RTE {
 
 		/// Gets the name of the current scene.
 		/// @return A string with the instance name of the scene.
-		std::string GetSceneName() const { return m_SceneName; }
+		const std::string& GetSceneName() const { return m_SceneName; }
 
 		/// Sets the name of the scene this is associated with.
 		/// @param sceneName The new name of the scene to load next game.
-		void SetSceneName(const std::string sceneName) { m_SceneName = sceneName; }
+		void SetSceneName(std::string sceneName) { m_SceneName = std::move(sceneName); }
 
 		/// Gets whether craft must be considered orbited if they reach the map border on non-wrapped maps.
 		/// @return Whether craft are considered orbited when at the border of a non-wrapping map.
@@ -228,7 +228,7 @@ namespace RTE {
 
 		/// Gets the total number of human players in the current Activity.
 		/// @return The total number of players in the current Activity.
-		int GetHumanCount() const;
+		uint8_t GetHumanCount() const;
 
 		/// Indicates whether a specific player is human in the current game, ie not an AI player and has a screen etc.
 		/// @param player Which player index to check.

--- a/Source/Entities/BunkerAssembly.cpp
+++ b/Source/Entities/BunkerAssembly.cpp
@@ -195,7 +195,7 @@ int BunkerAssembly::ReadProperty(const std::string_view& propName, Reader& reade
 		} else {
 			// Do not allow to define assemblies prior to corresponding assembly scheme
 			char s[256];
-			std::snprintf(s, sizeof(s), "Required BunkerAssemblyScheme '%s%' not found when trying to load BunkerAssembly '%s'! BunkerAssemblySchemes MUST be defined before dependent BunkerAssmeblies.", parentScheme.c_str(), m_PresetName.c_str());
+			std::snprintf(s, sizeof(s), "Required BunkerAssemblyScheme '%s' not found when trying to load BunkerAssembly '%s'! BunkerAssemblySchemes MUST be defined before dependent BunkerAssmeblies.", parentScheme.c_str(), m_PresetName.c_str());
 			RTEAbort(s);
 		}
 	});

--- a/Source/Entities/BunkerAssembly.h
+++ b/Source/Entities/BunkerAssembly.h
@@ -61,7 +61,7 @@ namespace RTE {
 
 		/// Description:
 		/// Return value:
-		std::string GetParentAssemblySchemeName() const { return m_ParentAssemblyScheme; }
+		const std::string& GetParentAssemblySchemeName() const { return m_ParentAssemblyScheme; }
 
 		/// Indicates whether this' current graphical representation overlaps
 		/// a point in absolute scene coordinates.
@@ -97,11 +97,11 @@ namespace RTE {
 
 		/// Gets the name of an assembly symmetric to this one.
 		/// @return Symmetric assembly name.
-		std::string GetSymmetricAssemblyName() const { return m_SymmetricAssembly; };
+		const std::string& GetSymmetricAssemblyName() const { return m_SymmetricAssembly; };
 
 		/// Sets the name of an assembly symmetric to this one.
 		/// @param newSymmetricAssembly Symmetric assembly name.
-		void SetSymmetricAssemblyName(std::string newSymmetricAssembly) { m_SymmetricAssembly = newSymmetricAssembly; };
+		void SetSymmetricAssemblyName(std::string newSymmetricAssembly) { m_SymmetricAssembly = std::move(newSymmetricAssembly); };
 
 		/// Draws this TerrainObject's current graphical representation to a
 		/// BITMAP of choice.

--- a/Source/Entities/BunkerAssemblyScheme.h
+++ b/Source/Entities/BunkerAssemblyScheme.h
@@ -129,11 +129,11 @@ namespace RTE {
 
 		/// Gets the name of the scheme symmetric to this one.
 		/// @return Symmetric scheme name.
-		std::string GetSymmetricSchemeName() const { return m_SymmetricScheme; }
+		const std::string& GetSymmetricSchemeName() const { return m_SymmetricScheme; }
 
 		/// Gets the name of group to which assemblies linked with this scheme must be added.
 		/// @return Assembly group name.
-		std::string GetAssemblyGroup() const { return m_AssemblyGroup; }
+		const std::string& GetAssemblyGroup() const { return m_AssemblyGroup; }
 
 		/// Returns the limit of these schemes per scene. 0 - no limit.
 		/// @return Scheme limit.

--- a/Source/Entities/Deployment.cpp
+++ b/Source/Entities/Deployment.cpp
@@ -50,7 +50,7 @@ int Deployment::Create() {
 }
 
 int Deployment::Create(std::string loadoutName, const Icon& icon, float spawnRadius) {
-	m_LoadoutName = loadoutName;
+	m_LoadoutName = std::move(loadoutName);
 	m_Icon = icon;
 	m_SpawnRadius = spawnRadius;
 	m_WalkRadius = 250;

--- a/Source/Entities/Deployment.h
+++ b/Source/Entities/Deployment.h
@@ -79,7 +79,7 @@ namespace RTE {
 
 		/// Gets a bitmap showing a good identifyable icon of this.
 		/// @return The Icon that represents this graphically.
-		Icon GetIcon() { return m_Icon; }
+		const Icon& GetIcon() { return m_Icon; }
 
 		/// Gets the radius around this deployment that gets checked if another
 		/// actor/item of the same type and name already exists and will block

--- a/Source/Entities/HDFirearm.cpp
+++ b/Source/Entities/HDFirearm.cpp
@@ -414,7 +414,7 @@ std::string HDFirearm::GetNextMagazineName() const {
 	return m_pMagazineReference->GetPresetName();
 }
 
-bool HDFirearm::SetNextMagazineName(std::string magName) {
+bool HDFirearm::SetNextMagazineName(const std::string& magName) {
 	const Magazine* pNewMag = dynamic_cast<const Magazine*>(g_PresetMan.GetEntityPreset("Magazine", magName));
 	if (pNewMag) {
 		m_pMagazineReference = pNewMag;

--- a/Source/Entities/HDFirearm.h
+++ b/Source/Entities/HDFirearm.h
@@ -101,7 +101,7 @@ namespace RTE {
 		/// this gun. This changes all future mags that will be reloaded.
 		/// @param magName The preset name of the new Magazine to load into this from now on.
 		/// @return Whether the specified magazine was found and successfully prepared.
-		bool SetNextMagazineName(std::string magName);
+		bool SetNextMagazineName(const std::string& magName);
 
 		/// Gets the number of rounds still in the loaded magazine. Negative value
 		/// means infinite ammo.

--- a/Source/Entities/Icon.h
+++ b/Source/Entities/Icon.h
@@ -53,11 +53,11 @@ namespace RTE {
 
 		/// Gets the array of 8-bit bitmaps of this Icon, as many as GetFrameCount says. Neither the array nor the BITMAPs are transferred ownership!
 		/// @return The BITMAPs in 8bpp of this Icon.
-		std::vector<BITMAP*> GetBitmaps8() const { return m_BitmapsIndexed; }
+		const std::vector<BITMAP*>& GetBitmaps8() const { return m_BitmapsIndexed; }
 
 		/// Gets the array of 32-bit bitmaps of this Icon, as many as GetFrameCount says. Neither the array nor the BITMAPs are transferred ownership!
 		/// @return The BITMAPs in 32bpp of this Icon.
-		std::vector<BITMAP*> GetBitmaps32() const { return m_BitmapsTrueColor; }
+		const std::vector<BITMAP*>& GetBitmaps32() const { return m_BitmapsTrueColor; }
 #pragma endregion
 
 #pragma region Operator Overloads

--- a/Source/Entities/MOSParticle.h
+++ b/Source/Entities/MOSParticle.h
@@ -31,7 +31,7 @@ namespace RTE {
 		/// @param lifetime The amount of time in ms this MOSParticle will exist. 0 means unlimited.
 		/// @return An error return value signaling success or any particular failure. Anything below 0 is an error signal.
 		int Create(ContentFile spriteFile, const int frameCount = 1, const float mass = 1, const Vector& position = Vector(0, 0), const Vector& velocity = Vector(0, 0), const unsigned long lifetime = 0) {
-			MOSprite::Create(spriteFile, frameCount, mass, position, velocity, lifetime);
+			MOSprite::Create(std::move(spriteFile), frameCount, mass, position, velocity, lifetime);
 			return 0;
 		}
 

--- a/Source/Entities/MOSRotating.cpp
+++ b/Source/Entities/MOSRotating.cpp
@@ -178,7 +178,7 @@ int MOSRotating::Create(ContentFile spriteFile,
                         const Vector& position,
                         const Vector& velocity,
                         const unsigned long lifetime) {
-	MOSprite::Create(spriteFile, frameCount, mass, position, velocity, lifetime);
+	MOSprite::Create(std::move(spriteFile), frameCount, mass, position, velocity, lifetime);
 
 	if (!m_pFlipBitmap && m_aSprite[0]) {
 		m_pFlipBitmap = create_bitmap_ex(8, m_aSprite[0]->w, m_aSprite[0]->h);

--- a/Source/Entities/MOSprite.cpp
+++ b/Source/Entities/MOSprite.cpp
@@ -78,7 +78,7 @@ int MOSprite::Create(ContentFile spriteFile,
                      const unsigned long lifetime) {
 	MovableObject::Create(mass, position, velocity, 0, 0, lifetime);
 
-	m_SpriteFile = spriteFile;
+	m_SpriteFile = std::move(spriteFile);
 	m_FrameCount = frameCount;
 	m_aSprite.clear();
 	m_SpriteFile.GetAsAnimation(m_aSprite, m_FrameCount);
@@ -180,18 +180,18 @@ int MOSprite::ReadProperty(const std::string_view& propName, Reader& reader) {
 	EndPropertyList;
 }
 
-void MOSprite::SetEntryWound(std::string presetName, std::string moduleName) {
+void MOSprite::SetEntryWound(const std::string& presetName, std::string moduleName) {
 	if (presetName == "")
 		m_pEntryWound = 0;
 	else
-		m_pEntryWound = dynamic_cast<const AEmitter*>(g_PresetMan.GetEntityPreset("AEmitter", presetName, moduleName));
+		m_pEntryWound = dynamic_cast<const AEmitter*>(g_PresetMan.GetEntityPreset("AEmitter", presetName, std::move(moduleName)));
 }
 
-void MOSprite::SetExitWound(std::string presetName, std::string moduleName) {
+void MOSprite::SetExitWound(const std::string& presetName, std::string moduleName) {
 	if (presetName == "")
 		m_pExitWound = 0;
 	else
-		m_pExitWound = dynamic_cast<const AEmitter*>(g_PresetMan.GetEntityPreset("AEmitter", presetName, moduleName));
+		m_pExitWound = dynamic_cast<const AEmitter*>(g_PresetMan.GetEntityPreset("AEmitter", presetName, std::move(moduleName)));
 }
 
 std::string MOSprite::GetEntryWoundPresetName() const {

--- a/Source/Entities/MOSprite.h
+++ b/Source/Entities/MOSprite.h
@@ -305,11 +305,11 @@ namespace RTE {
 
 		/// Sets entry wound emitter for this MOSprite
 		/// @param presetName Emitter preset name and module name
-		void SetEntryWound(std::string presetName, std::string moduleName);
+		void SetEntryWound(const std::string& presetName, std::string moduleName);
 
 		/// Sets exit wound emitter for this MOSprite
 		/// @param presetName Emitter preset name and module name
-		void SetExitWound(std::string presetName, std::string moduleName);
+		void SetExitWound(const std::string& presetName, std::string moduleName);
 
 		/// Returns entry wound emitter preset name for this MOSprite
 		/// @return Wound emitter preset name

--- a/Source/Entities/MetaPlayer.h
+++ b/Source/Entities/MetaPlayer.h
@@ -54,11 +54,11 @@ namespace RTE {
 #pragma region Getters and Setters
 		/// Gets the name of the MetaPlayer.
 		/// @return The name of the player.
-		std::string GetName() const { return m_Name; }
+		const std::string& GetName() const { return m_Name; }
 
 		/// Sets the name of the MetaPlayer.
 		/// @param newName The new name to set.
-		void SetName(std::string newName) { m_Name = newName; }
+		void SetName(std::string newName) { m_Name = std::move(newName); }
 
 		/// Gets the Team of this MetaPlayer.
 		/// @return The Team of this player.
@@ -107,11 +107,11 @@ namespace RTE {
 
 		/// Gets the name of the scene this MetaPlayer is targeting for offensive.
 		/// @return The name of the Scene this MetaPlayer is targeting.
-		std::string GetOffensiveTargetName() const { return m_OffensiveTarget; }
+		const std::string& GetOffensiveTargetName() const { return m_OffensiveTarget; }
 
 		/// Sets the name of the scene this MetaPlayer is targeting for offensive.
 		/// @param targetName The name of the Scene this MetaPlayer is targeting.
-		void SetOffensiveTargetName(std::string targetName) { m_OffensiveTarget = targetName; }
+		void SetOffensiveTargetName(std::string targetName) { m_OffensiveTarget = std::move(targetName); }
 #pragma endregion
 
 #pragma region Funds and Costs

--- a/Source/Entities/MetaSave.cpp
+++ b/Source/Entities/MetaSave.cpp
@@ -31,7 +31,7 @@ int MetaSave::Create(std::string savePath) {
 		g_ConsoleMan.PrintString("ERROR: Tried to save a Metagame that isn't in progress!?");
 		return -1;
 	}
-	m_SavePath = savePath;
+	m_SavePath = std::move(savePath);
 
 	m_PlayerCount = g_MetaMan.m_Players.size();
 	m_Difficulty = g_MetaMan.m_Difficulty;

--- a/Source/Entities/MetaSave.h
+++ b/Source/Entities/MetaSave.h
@@ -44,7 +44,7 @@ namespace RTE {
 #pragma region Getters
 		/// Gets the full path to the ini file that stores the state of the MetaMan this is associated with.
 		/// @return The path to the ini with the MetaMan state info.
-		std::string GetSavePath() const { return m_SavePath; }
+		const std::string& GetSavePath() const { return m_SavePath; }
 
 		/// Gets the total number of players this game has (including AIs).
 		/// @return The player count.

--- a/Source/Entities/MovableObject.h
+++ b/Source/Entities/MovableObject.h
@@ -391,7 +391,7 @@ namespace RTE {
 
 		/// Gets the file path of this MovableObject's current screen effect.
 		/// @param pathToFile A string containing the file path of the new screen effect.
-		void SetScreenEffectPath(std::string pathToFile) {
+		void SetScreenEffectPath(std::string& pathToFile) {
 			m_ScreenEffectFile.SetDataPath(pathToFile);
 			m_pScreenEffect = m_ScreenEffectFile.GetAsBitmap();
 			m_ScreenEffectHash = m_ScreenEffectFile.GetHash();

--- a/Source/Entities/Scene.cpp
+++ b/Source/Entities/Scene.cpp
@@ -815,7 +815,7 @@ int Scene::ExpandAIPlanAssemblySchemes() {
 	return 0;
 }
 
-int Scene::SaveData(std::string pathBase) {
+int Scene::SaveData(const std::string& pathBase) {
 	const std::string fullPathBase = g_PresetMan.GetFullModulePath(pathBase);
 	if (fullPathBase.empty())
 		return -1;

--- a/Source/Entities/Scene.h
+++ b/Source/Entities/Scene.h
@@ -67,7 +67,7 @@ namespace RTE {
 			}
 			Area(std::string name) {
 				Clear();
-				m_Name = name;
+				m_Name = std::move(name);
 				Create();
 			}
 			Area(const Area& reference) {
@@ -164,7 +164,7 @@ namespace RTE {
 
 			/// Gets the name of the Area
 			/// @return The name used to ID this Area.
-			std::string GetName() const { return m_Name; }
+			const std::string& GetName() const { return m_Name; }
 
 			/// Protected member variable and method declarations
 		protected:
@@ -244,7 +244,7 @@ namespace RTE {
 		/// everything up to the extension. "FG" and "Mat" etc will be added.
 		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
-		int SaveData(std::string pathBase);
+		int SaveData(const std::string& pathBase);
 
 		// Gets copied bitmaps of our scene layers, for saving.
 		// @return A list of SceneLayerInfo including our name and a copied bitmap.
@@ -549,7 +549,7 @@ namespace RTE {
 
 		/// Returns parent scene name of this metascene.
 		/// @return Name of a parent scene.
-		std::string GetMetasceneParent() const { return m_MetasceneParent; }
+		const std::string& GetMetasceneParent() const { return m_MetasceneParent; }
 
 		/// Sets the specified location of this Scene in the scene
 		/// @param newLocation A Vector with the desired location of this Scene in the scene.

--- a/Source/Entities/SoundSet.cpp
+++ b/Source/Entities/SoundSet.cpp
@@ -32,7 +32,7 @@ int SoundSet::Create(const SoundSet& reference) {
 	m_SoundSelectionCycleMode = reference.m_SoundSelectionCycleMode;
 	m_CurrentSelection = reference.m_CurrentSelection;
 	for (SoundData referenceSoundData: reference.m_SoundData) {
-		m_SoundData.push_back(referenceSoundData);
+		m_SoundData.push_back(std::move(referenceSoundData));
 	}
 	for (const SoundSet* referenceSoundSet: reference.m_SubSoundSets) {
 		SoundSet* soundSet = new SoundSet(*referenceSoundSet);

--- a/Source/GUI/GUIBanner.cpp
+++ b/Source/GUI/GUIBanner.cpp
@@ -40,7 +40,7 @@ bool GUIBanner::Create(const std::string fontFilePath, const std::string fontBlu
 	int y, dotColor;
 	for (int mode = REGULAR; mode < FONTMODECOUNT; ++mode) {
 		// Load the font images
-		fontFile.SetDataPath(filePaths[mode].c_str());
+		fontFile.SetDataPath(filePaths[mode]);
 		m_pFontImage[mode] = fontFile.GetAsBitmap(bitDepth == 8 ? COLORCONV_REDUCE_TO_256 : COLORCONV_8_TO_32);
 		RTEAssert(m_pFontImage[mode], "Couldn't load font bitmap for banner font from this file:\n" + fontFilePath);
 
@@ -345,7 +345,7 @@ void GUIBanner::Draw(BITMAP* pTargetBitmap) {
 	}
 }
 
-int GUIBanner::CalculateWidth(const std::string text, FontMode mode) const {
+int GUIBanner::CalculateWidth(const std::string& text, FontMode mode) const {
 	unsigned char c;
 	int Width = 0;
 

--- a/Source/GUI/GUIBanner.h
+++ b/Source/GUI/GUIBanner.h
@@ -84,7 +84,7 @@ namespace RTE {
 
 		/// Gets the currently displayed text string.
 		/// @return The currently displayed text string.
-		std::string GetBannerText() const { return m_BannerText; }
+		const std::string& GetBannerText() const { return m_BannerText; }
 
 		/// Gets the current state of the overall animation of this banner.
 		/// @return The current state of the animation.
@@ -96,7 +96,7 @@ namespace RTE {
 
 		/// Calculates the width of a piece of text.
 		/// @param Text Text.
-		int CalculateWidth(const std::string Text, FontMode mode) const;
+		int CalculateWidth(const std::string& Text, FontMode mode) const;
 
 		/// Calculates the width of a piece of text.
 		/// @param Character Character.

--- a/Source/GUI/GUIButton.cpp
+++ b/Source/GUI/GUIButton.cpp
@@ -6,15 +6,17 @@
 using namespace RTE;
 
 GUIButton::GUIButton(GUIManager* Manager, GUIControlManager* ControlManager) :
-    GUIControl(), GUIPanel(Manager) {
-	m_ControlID = "BUTTON";
-	m_DrawBitmap = nullptr;
+	GUIControl(),
+	GUIPanel(Manager),
+	m_DrawBitmap(nullptr),
+	m_Pushed(false),
+	m_Over(false),
+	m_Text(nullptr),
+	m_Icon(nullptr),
+	m_BorderSizes(nullptr) {
+
 	m_ControlManager = ControlManager;
-	m_Pushed = false;
-	m_Over = false;
-	m_Text = nullptr;
-	m_Icon = nullptr;
-	m_BorderSizes = nullptr;
+	m_ControlID = "BUTTON";
 }
 
 void GUIButton::Create(const std::string& Name, int X, int Y, int Width, int Height) {

--- a/Source/GUI/GUICheckbox.cpp
+++ b/Source/GUI/GUICheckbox.cpp
@@ -241,7 +241,7 @@ void GUICheckbox::SetText(const std::string& Text) {
 	m_Text = Text;
 }
 
-std::string GUICheckbox::GetText() const {
+const std::string& GUICheckbox::GetText() const {
 	return m_Text;
 }
 

--- a/Source/GUI/GUICheckbox.h
+++ b/Source/GUI/GUICheckbox.h
@@ -87,7 +87,7 @@ namespace RTE {
 		void SetText(const std::string& Text);
 
 		/// Gets the text.
-		std::string GetText() const;
+		const std::string& GetText() const;
 
 		/// Sets the check state.
 		/// @param Check Check state.

--- a/Source/GUI/GUIControl.cpp
+++ b/Source/GUI/GUIControl.cpp
@@ -57,7 +57,7 @@ std::string GUIControl::GetToolTip() {
 	return tip;
 }
 
-std::string GUIControl::GetID() const {
+const std::string& GUIControl::GetID() const {
 	return m_ControlID;
 }
 
@@ -259,7 +259,7 @@ bool GUIControl::IsContainer() {
 	return m_IsContainer;
 }
 
-void GUIControl::RemoveChild(const std::string Name) {
+void GUIControl::RemoveChild(const std::string& Name) {
 	// Note: We do NOT free the children because they are still linked in through their panels. This merely removes the control from the list.
 	// This will cause a small memory leak, but this is only designed for the GUI Editor and is a bit of a hack.
 	std::vector<GUIControl*>::iterator it;

--- a/Source/GUI/GUIControl.h
+++ b/Source/GUI/GUIControl.h
@@ -57,7 +57,7 @@ namespace RTE {
 		std::string GetToolTip();
 
 		/// Returns a string representing the control's ID
-		std::string GetID() const;
+		const std::string& GetID() const;
 
 		/// Returns the anchor flags.
 		int GetAnchor();
@@ -122,7 +122,7 @@ namespace RTE {
 
 		/// Removes a child based on name.
 		/// @param Name Child Name.
-		void RemoveChild(const std::string Name);
+		void RemoveChild(const std::string& Name);
 
 		/// Removes all the children.
 		void RemoveChildren();

--- a/Source/GUI/GUIControlManager.cpp
+++ b/Source/GUI/GUIControlManager.cpp
@@ -378,7 +378,7 @@ bool GUIControlManager::Save(GUIWriter* W) {
 bool GUIControlManager::Load(const std::string& Filename, bool keepOld) {
 	GUIReader reader;
 	const std::string pathFile = g_PresetMan.GetFullModulePath(Filename);
-	if (reader.Create(pathFile.c_str()) != 0) {
+	if (reader.Create(pathFile) != 0) {
 		return false;
 	}
 

--- a/Source/GUI/GUIFont.cpp
+++ b/Source/GUI/GUIFont.cpp
@@ -4,20 +4,19 @@
 
 using namespace RTE;
 
-GUIFont::GUIFont(const std::string& Name) {
-	m_Screen = nullptr;
-	m_Font = nullptr;
-	m_FontHeight = 0;
-	m_Name = Name;
-	m_Kerning = 0;
-	m_Leading = 0;
+GUIFont::GUIFont(const std::string& Name) :
+	m_Font(nullptr),
+	m_Screen(nullptr),
+	m_FontHeight(0),
+	m_MainColor(15),
+	m_CurrentColor(m_MainColor),
+	m_CurrentBitmap(nullptr),
+	m_Name(Name), // Color index of the main font color
+	m_CharIndexCap(256),
+	m_Kerning(0),
+	m_Leading(0) {
+
 	m_ColorCache.clear();
-
-	m_MainColor = 15; // Color index of the main font color
-	m_CurrentColor = m_MainColor;
-	m_CurrentBitmap = nullptr;
-
-	m_CharIndexCap = 256;
 }
 
 bool GUIFont::Load(GUIScreen* Screen, const std::string& Filename) {

--- a/Source/GUI/GUILabel.cpp
+++ b/Source/GUI/GUILabel.cpp
@@ -4,18 +4,20 @@
 using namespace RTE;
 
 GUILabel::GUILabel(GUIManager* Manager, GUIControlManager* ControlManager) :
-    GUIControl(), GUIPanel(Manager) {
+	GUIControl(),
+	GUIPanel(Manager),
+	m_Text(""),
+	m_HAlignment(GUIFont::Left),
+	m_VAlignment(GUIFont::Middle),
+	m_HorizontalOverflowScroll(false),
+	m_VerticalOverflowScroll(false),
+	m_OverflowScrollState(OverflowScrollState::Deactivated),
+	m_OverflowScrollTimer(Timer()) {
+
 	m_ControlID = "LABEL";
 	m_ControlManager = ControlManager;
 	m_Font = nullptr;
 	m_FontColor = 0;
-	m_Text = "";
-	m_HAlignment = GUIFont::Left;
-	m_VAlignment = GUIFont::Middle;
-	m_HorizontalOverflowScroll = false;
-	m_VerticalOverflowScroll = false;
-	m_OverflowScrollState = OverflowScrollState::Deactivated;
-	m_OverflowScrollTimer = Timer();
 }
 
 void GUILabel::Create(const std::string& Name, int X, int Y, int Width, int Height) {

--- a/Source/GUI/GUIProperties.cpp
+++ b/Source/GUI/GUIProperties.cpp
@@ -4,13 +4,15 @@
 
 using namespace RTE;
 
-GUIProperties::GUIProperties(const std::string& Name) {
-	m_Name = Name;
+GUIProperties::GUIProperties(std::string Name) :
+	m_Name(std::move(Name)) {
+
 	m_VariableList.clear();
 }
 
-GUIProperties::GUIProperties() {
-	m_Name = "";
+GUIProperties::GUIProperties() :
+	m_Name("") {
+
 	m_VariableList.clear();
 }
 
@@ -234,7 +236,7 @@ bool GUIProperties::GetValue(const std::string& Variable, bool* Value) {
 	return true;
 }
 
-std::string GUIProperties::GetName() const {
+const std::string& GUIProperties::GetName() const {
 	return m_Name;
 }
 

--- a/Source/GUI/GUIProperties.h
+++ b/Source/GUI/GUIProperties.h
@@ -9,7 +9,7 @@ namespace RTE {
 		/// Constructor method used to instantiate a GUIProperties object in
 		/// system memory.
 		/// @param Name Name of section.
-		explicit GUIProperties(const std::string& Name);
+		explicit GUIProperties(std::string Name);
 
 		/// Constructor method used to instantiate a GUIProperties object in
 		/// system memory.
@@ -79,7 +79,7 @@ namespace RTE {
 		bool GetValue(const std::string& Variable, bool* Value);
 
 		/// Gets the property name
-		std::string GetName() const;
+		const std::string& GetName() const;
 
 		/// Converts the properties to a string
 		std::string ToString();

--- a/Source/GUI/GUIRadioButton.cpp
+++ b/Source/GUI/GUIRadioButton.cpp
@@ -4,15 +4,17 @@
 using namespace RTE;
 
 GUIRadioButton::GUIRadioButton(GUIManager* Manager, GUIControlManager* ControlManager) :
-    GUIControl(), GUIPanel(Manager) {
+	GUIControl(),
+	GUIPanel(Manager),
+	m_Image(nullptr),
+	m_Checked(false),
+	m_Mouseover(false),
+	m_Text("") {
+
 	m_ControlID = "RADIOBUTTON";
-	m_Image = nullptr;
 	m_ControlManager = ControlManager;
-	m_Checked = false;
 	m_Font = 0;
-	m_Mouseover = false;
 	m_FontColor = 0;
-	m_Text = "";
 }
 
 void GUIRadioButton::Create(const std::string& Name, int X, int Y, int Width, int Height) {
@@ -270,7 +272,7 @@ void GUIRadioButton::SetText(const std::string& Text) {
 	m_Text = Text;
 }
 
-std::string GUIRadioButton::GetText() const {
+const std::string& GUIRadioButton::GetText() const {
 	return m_Text;
 }
 

--- a/Source/GUI/GUIRadioButton.h
+++ b/Source/GUI/GUIRadioButton.h
@@ -84,7 +84,7 @@ namespace RTE {
 		void SetText(const std::string& Text);
 
 		/// Gets the text.
-		std::string GetText() const;
+		const std::string& GetText() const;
 
 		/// Applies new properties to the control.
 		/// @param Props GUIProperties.

--- a/Source/GUI/GUIReader.cpp
+++ b/Source/GUI/GUIReader.cpp
@@ -42,7 +42,7 @@ std::istream* GUIReader::GetStream() const {
 	return m_Stream.get();
 }
 
-std::string GUIReader::GetCurrentFilePath() const {
+const std::string& GUIReader::GetCurrentFilePath() const {
 	return m_FilePath;
 }
 

--- a/Source/GUI/GUIReader.h
+++ b/Source/GUI/GUIReader.h
@@ -25,7 +25,7 @@ namespace RTE {
 
 		/// Gets the path of the current file this reader is reading from.
 		/// @return A string with the path, relative from the working directory.
-		std::string GetCurrentFilePath() const;
+		const std::string& GetCurrentFilePath() const;
 
 		/// Gets the line of the current file line this reader is reading from.
 		/// @return A string with the line number that will be read from next.

--- a/Source/GUI/GUITab.cpp
+++ b/Source/GUI/GUITab.cpp
@@ -4,15 +4,17 @@
 using namespace RTE;
 
 GUITab::GUITab(GUIManager* Manager, GUIControlManager* ControlManager) :
-    GUIControl(), GUIPanel(Manager) {
+	GUIControl(),
+	GUIPanel(Manager),
+	m_Image(nullptr),
+	m_Selected(false),
+	m_Mouseover(false),
+	m_Text("") {
+
 	m_ControlID = "TAB";
-	m_Image = nullptr;
 	m_ControlManager = ControlManager;
-	m_Selected = false;
 	m_Font = nullptr;
-	m_Mouseover = false;
 	m_FontColor = 0;
-	m_Text = "";
 }
 
 void GUITab::Create(const std::string& Name, int X, int Y, int Width, int Height) {
@@ -272,7 +274,7 @@ void GUITab::SetText(const std::string& Text) {
 	m_Text = Text;
 }
 
-std::string GUITab::GetText() const {
+const std::string& GUITab::GetText() const {
 	return m_Text;
 }
 

--- a/Source/GUI/GUITab.h
+++ b/Source/GUI/GUITab.h
@@ -85,7 +85,7 @@ namespace RTE {
 		void SetText(const std::string& Text);
 
 		/// Gets the text.
-		std::string GetText() const;
+		const std::string& GetText() const;
 
 		/// Applies new properties to the control.
 		/// @param Props GUIProperties.

--- a/Source/GUI/GUITextPanel.cpp
+++ b/Source/GUI/GUITextPanel.cpp
@@ -30,26 +30,25 @@ GUITextPanel::GUITextPanel(GUIManager* Manager) :
 // TODO: Both constructors use a common clear function?? Same with other panels
 
 GUITextPanel::GUITextPanel() :
-    GUIPanel() {
+    GUIPanel(),
+	m_FontSelectColor(0),
+	m_Text(""),
+	m_Locked(false),
+	m_WidthMargin(3),
+	m_HeightMargin(0),
+	m_CursorX(m_CursorY = 0),
+	m_CursorIndex(0),
+	m_StartIndex(0),
+	m_GotSelection(false),
+	m_SelectedColorIndex(0),
+	m_MaxTextLength(0),
+	m_NumericOnly(false),
+	m_MaxNumericValue(0) {
+
 	m_Font = nullptr;
-	m_Text = "";
-	m_CursorX = m_CursorY = 0;
-	m_CursorIndex = 0;
 	m_CursorColor = 0;
-	m_BlinkTimer.Reset();
-
 	m_FontColor = 0;
-	m_FontSelectColor = 0;
-	m_StartIndex = 0;
-	m_GotSelection = false;
-	m_SelectedColorIndex = 0;
-	m_Locked = false;
-	m_WidthMargin = 3;
-	m_HeightMargin = 0;
-
-	m_MaxTextLength = 0;
-	m_NumericOnly = false;
-	m_MaxNumericValue = 0;
+	m_BlinkTimer.Reset();
 }
 
 void GUITextPanel::Create(int X, int Y, int Width, int Height) {

--- a/Source/GUI/GUITextPanel.h
+++ b/Source/GUI/GUITextPanel.h
@@ -71,10 +71,10 @@ namespace RTE {
 		void SetRightText(const std::string& rightText);
 
 		/// Gets the text in the textpanel.
-		std::string GetText() const { return m_Text; }
+		const std::string& GetText() const { return m_Text; }
 
 		/// Gets the extra text which appears right-justified in the textpanel.
-		std::string GetRightText() const { return m_RightText; }
+		const std::string& GetRightText() const { return m_RightText; }
 
 		/// Sets the start and end indexes of the selection text.
 		/// @param Start Start, End.

--- a/Source/GUI/GUIWriter.cpp
+++ b/Source/GUI/GUIWriter.cpp
@@ -32,15 +32,15 @@ int GUIWriter::Create(const std::string& fileName, bool append) {
 	return 0;
 }
 
-std::string GUIWriter::GetFilePath() const {
+const std::string& GUIWriter::GetFilePath() const {
 	return m_FilePath;
 }
 
-std::string GUIWriter::GetFileName() const {
+const std::string& GUIWriter::GetFileName() const {
 	return m_FileName;
 }
 
-std::string GUIWriter::GetFolderPath() const {
+const std::string& GUIWriter::GetFolderPath() const {
 	return m_FolderPath;
 }
 

--- a/Source/GUI/GUIWriter.h
+++ b/Source/GUI/GUIWriter.h
@@ -24,15 +24,15 @@ namespace RTE {
 #pragma region Getters
 		/// Gets the path to the file being written.
 		/// @return The full path to the file being written.
-		std::string GetFilePath() const;
+		const std::string& GetFilePath() const;
 
 		/// Gets the name (without path) of the file being written.
 		/// @return The name of file being written.
-		std::string GetFileName() const;
+		const std::string& GetFileName() const;
 
 		/// Gets the folder path (without filename) to where the file is being written.
 		/// @return The name of folder being written in.
-		std::string GetFolderPath() const;
+		const std::string& GetFolderPath() const;
 #pragma endregion
 
 #pragma region Writing Operations

--- a/Source/GUI/Wrappers/AllegroScreen.cpp
+++ b/Source/GUI/Wrappers/AllegroScreen.cpp
@@ -5,9 +5,9 @@
 
 using namespace RTE;
 
-AllegroScreen::AllegroScreen(BITMAP* backBuffer) {
-	m_BackBufferBitmap = std::make_unique<AllegroBitmap>(backBuffer);
-}
+AllegroScreen::AllegroScreen(BITMAP* backBuffer) :
+	m_BackBufferBitmap(std::make_unique<AllegroBitmap>(backBuffer))
+{}
 
 AllegroScreen::~AllegroScreen() {
 	Destroy();

--- a/Source/GUI/Wrappers/GUIInputWrapper.cpp
+++ b/Source/GUI/Wrappers/GUIInputWrapper.cpp
@@ -11,9 +11,10 @@
 using namespace RTE;
 
 GUIInputWrapper::GUIInputWrapper(int whichPlayer, bool keyJoyMouseCursor) :
-    GUIInput(whichPlayer, keyJoyMouseCursor) {
-	m_KeyTimer = std::make_unique<Timer>();
-	m_CursorAccelTimer = std::make_unique<Timer>();
+	GUIInput(whichPlayer, keyJoyMouseCursor),
+	m_KeyTimer(std::make_unique<Timer>()),
+	m_CursorAccelTimer(std::make_unique<Timer>())
+	{
 
 	memset(m_KeyboardBuffer, 0, sizeof(uint8_t) * GUIInput::Constants::KEYBOARD_BUFFER_SIZE);
 	memset(m_ScanCodeState, 0, sizeof(uint8_t) * GUIInput::Constants::KEYBOARD_BUFFER_SIZE);

--- a/Source/Lua/LuaBindingsActivities.cpp
+++ b/Source/Lua/LuaBindingsActivities.cpp
@@ -152,7 +152,7 @@ LuaBindingRegisterFunctionDefinitionForType(ActivityLuaBindings, GameActivity) {
 	    .def("ClearObjectivePoints", &GameActivity::ClearObjectivePoints)
 	    .def("AddOverridePurchase", &GameActivity::AddOverridePurchase)
 	    .def("SetOverridePurchaseList", (int(GameActivity::*)(const Loadout*, int)) & GameActivity::SetOverridePurchaseList)
-	    .def("SetOverridePurchaseList", (int(GameActivity::*)(std::string, int)) & GameActivity::SetOverridePurchaseList)
+	    .def("SetOverridePurchaseList", (int(GameActivity::*)(const std::string&, int)) & GameActivity::SetOverridePurchaseList)
 	    .def("ClearOverridePurchase", &GameActivity::ClearOverridePurchase)
 	    .def("CreateDelivery", (bool(GameActivity::*)(int)) & GameActivity::CreateDelivery)
 	    .def("CreateDelivery", (bool(GameActivity::*)(int, int)) & GameActivity::CreateDelivery)

--- a/Source/Lua/LuaBindingsManagers.cpp
+++ b/Source/Lua/LuaBindingsManagers.cpp
@@ -204,8 +204,8 @@ LuaBindingRegisterFunctionDefinitionForType(ManagerLuaBindings, PresetMan) {
 	    .def("GetTotalModuleCount", &PresetMan::GetTotalModuleCount)
 	    .def("GetOfficialModuleCount", &PresetMan::GetOfficialModuleCount)
 	    .def("AddPreset", &PresetMan::AddEntityPreset)
-	    .def("GetPreset", (const Entity* (PresetMan::*)(std::string, std::string, int)) & PresetMan::GetEntityPreset)
-	    .def("GetPreset", (const Entity* (PresetMan::*)(std::string, std::string, std::string)) & PresetMan::GetEntityPreset)
+	    .def("GetPreset", (const Entity* (PresetMan::*)(const std::string&, std::string, int)) & PresetMan::GetEntityPreset)
+	    .def("GetPreset", (const Entity* (PresetMan::*)(const std::string&, std::string, std::string)) & PresetMan::GetEntityPreset)
 	    .def("GetLoadout", (Actor * (PresetMan::*)(std::string, std::string, bool)) & PresetMan::GetLoadout, luabind::adopt(luabind::result))
 	    .def("GetLoadout", (Actor * (PresetMan::*)(std::string, int, bool)) & PresetMan::GetLoadout, luabind::adopt(luabind::result))
 	    .def("GetRandomOfGroup", &PresetMan::GetRandomOfGroup)
@@ -305,8 +305,8 @@ LuaBindingRegisterFunctionDefinitionForType(ManagerLuaBindings, SceneMan) {
 	    .property("KgPerOz", &SceneMan::GetKgPerOz)
 	    .property("ScrapCompactingHeight", &SceneMan::GetScrapCompactingHeight, &SceneMan::SetScrapCompactingHeight)
 
-	    .def("LoadScene", (int(SceneMan::*)(std::string, bool, bool)) & SceneMan::LoadScene)
-	    .def("LoadScene", (int(SceneMan::*)(std::string, bool)) & SceneMan::LoadScene)
+	    .def("LoadScene", (int(SceneMan::*)(const std::string&, bool, bool)) & SceneMan::LoadScene)
+	    .def("LoadScene", (int(SceneMan::*)(const std::string&, bool)) & SceneMan::LoadScene)
 
 	    .def("GetTerrain", &SceneMan::GetTerrain)
 	    .def("GetMaterial", &SceneMan::GetMaterial)

--- a/Source/Managers/ActivityMan.cpp
+++ b/Source/Managers/ActivityMan.cpp
@@ -283,7 +283,7 @@ bool ActivityMan::LoadAndLaunchGame(const std::string& fileName) {
 	unz_file_info info;
 	char* buffer = nullptr;
 
-	auto unzipFileIntoBuffer = [&](std::string fullFileName) {
+	auto unzipFileIntoBuffer = [&](const std::string& fullFileName) {
 		// These need to use NULL instead of nullptr to compile on Linux/OSX?
 		if (unzLocateFile(zippedSaveFile, fullFileName.c_str(), NULL) == UNZ_END_OF_LIST_OF_FILE) {
 			return false;

--- a/Source/Managers/ActivityMan.h
+++ b/Source/Managers/ActivityMan.h
@@ -83,7 +83,7 @@ namespace RTE {
 #pragma region Default Activity Handling
 		/// Gets the type name of the default Activity to be loaded if nothing else is available.
 		/// @return The default Activity type name.
-		std::string GetDefaultActivityType() const { return m_DefaultActivityType; }
+		const std::string& GetDefaultActivityType() const { return m_DefaultActivityType; }
 
 		/// Sets the type name of the default Activity to be loaded if nothing else is available.
 		/// @param defaultActivityType The default Activity type name.
@@ -91,7 +91,7 @@ namespace RTE {
 
 		/// Gets the name of the default Activity to be loaded if nothing else is available.
 		/// @return The default Activity preset name.
-		std::string GetDefaultActivityName() const { return m_DefaultActivityName; }
+		const std::string& GetDefaultActivityName() const { return m_DefaultActivityName; }
 
 		/// Sets the preset name of the default Activity to be loaded if nothing else is available.
 		/// @param defaultActivityName The default Activity preset name.

--- a/Source/Managers/AudioMan.cpp
+++ b/Source/Managers/AudioMan.cpp
@@ -3,12 +3,9 @@
 #include "CameraMan.h"
 #include "ConsoleMan.h"
 #include "FrameMan.h"
-#include "SettingsMan.h"
 #include "SceneMan.h"
 #include "ActivityMan.h"
 #include "SoundContainer.h"
-#include "GUISound.h"
-#include "PresetMan.h"
 #include "WindowMan.h"
 #include "SoundSet.h"
 
@@ -159,7 +156,7 @@ void AudioMan::Update() {
 
 		if (!g_ActivityMan.ActivityPaused()) {
 			const Activity* currentActivity = g_ActivityMan.GetActivity();
-			int currentActivityHumanCount = m_IsInMultiplayerMode ? 1 : currentActivity->GetHumanCount();
+			uint8_t currentActivityHumanCount = m_IsInMultiplayerMode ? 1 : currentActivity->GetHumanCount();
 
 			if (m_CurrentActivityHumanPlayerPositions.size() != currentActivityHumanCount) {
 				status = status == FMOD_OK ? m_AudioSystem->set3DNumListeners(currentActivityHumanCount) : status;
@@ -214,11 +211,16 @@ void AudioMan::SetGlobalPitch(float pitch, bool includeImmobileSounds, bool incl
 	}
 
 	m_GlobalPitch = std::clamp(pitch, 0.125F, 8.0F);
+
+	m_SFXChannelGroup->setPitch(m_GlobalPitch);
+
+	if (includeImmobileSounds) {
+		m_UIChannelGroup->setPitch(m_GlobalPitch);
+	}
+
 	if (includeMusic) {
 		m_MusicChannelGroup->setPitch(m_GlobalPitch);
 	}
-
-	m_SFXChannelGroup->setPitch(m_GlobalPitch);
 }
 
 bool AudioMan::SetMusicPitch(float pitch) {
@@ -586,7 +588,7 @@ bool AudioMan::StopSoundContainerPlayingChannels(SoundContainer* soundContainer,
 		RegisterSoundEvent(player, SOUND_STOP, soundContainer);
 	}
 
-	FMOD_RESULT result;
+	FMOD_RESULT result = FMOD_OK;
 	FMOD::Channel* soundChannel;
 
 	const std::unordered_set<int>* channels = soundContainer->GetPlayingChannels();
@@ -660,8 +662,7 @@ void AudioMan::Update3DEffectsForSFXChannels() {
 		result = m_SFXChannelGroup->getChannel(i, &soundChannel);
 		FMOD_MODE mode;
 		result = (result == FMOD_OK) ? soundChannel->getMode(&mode) : result;
-		unsigned modeResult = mode & FMOD_2D;
-		if (modeResult == 0) {
+		if (result == FMOD_OK && (mode & FMOD_2D) == 0) {
 			FMOD_VECTOR channelPosition;
 			result = result == FMOD_OK ? soundChannel->get3DAttributes(&channelPosition, nullptr) : result;
 			result = result == FMOD_OK ? UpdatePositionalEffectsForSoundChannel(soundChannel, &channelPosition) : result;
@@ -672,13 +673,15 @@ void AudioMan::Update3DEffectsForSFXChannels() {
 				float doubleMinimumDistanceForPanning = m_MinimumDistanceForPanning * 2.0F;
 				void* userData;
 				result = result == FMOD_OK ? soundChannel->getUserData(&userData) : result;
-				const SoundContainer* soundContainer = static_cast<SoundContainer*>(userData);
-				if (sqrDistanceToPlayer < (m_MinimumDistanceForPanning * m_MinimumDistanceForPanning) || soundContainer->GetCustomPanValue() != 0.0f) {
-					soundChannel->set3DLevel(0);
-				} else if (sqrDistanceToPlayer < (doubleMinimumDistanceForPanning * doubleMinimumDistanceForPanning)) {
-					soundChannel->set3DLevel(Lerp(0, 1, 0, m_SoundPanningEffectStrength * soundContainer->GetPanningStrengthMultiplier(), channel3dLevel));
-				} else {
-					soundChannel->set3DLevel(m_SoundPanningEffectStrength * soundContainer->GetPanningStrengthMultiplier());
+				if (result == FMOD_OK) {
+					const SoundContainer* soundContainer = static_cast<SoundContainer*>(userData);
+					if (sqrDistanceToPlayer < (m_MinimumDistanceForPanning * m_MinimumDistanceForPanning) || soundContainer->GetCustomPanValue() != 0.0f) {
+						result = soundChannel->set3DLevel(0);
+					} else if (sqrDistanceToPlayer < (doubleMinimumDistanceForPanning * doubleMinimumDistanceForPanning)) {
+						result = soundChannel->set3DLevel(Lerp(0, 1, 0, m_SoundPanningEffectStrength * soundContainer->GetPanningStrengthMultiplier(), channel3dLevel));
+					} else {
+						result = soundChannel->set3DLevel(m_SoundPanningEffectStrength * soundContainer->GetPanningStrengthMultiplier());
+					}
 				}
 			}
 		}
@@ -691,10 +694,13 @@ void AudioMan::Update3DEffectsForSFXChannels() {
 }
 
 FMOD_RESULT AudioMan::UpdatePositionalEffectsForSoundChannel(FMOD::Channel* soundChannel, const FMOD_VECTOR* positionOverride) const {
-	FMOD_RESULT result = FMOD_OK;
-
 	void* userData;
-	result = result == FMOD_OK ? soundChannel->getUserData(&userData) : result;
+	FMOD_RESULT result = soundChannel->getUserData(&userData);
+
+	if (result != FMOD_OK) {
+		return result;
+	}
+
 	const SoundContainer* channelSoundContainer = static_cast<SoundContainer*>(userData);
 
 	bool sceneWraps = g_SceneMan.SceneWrapsX();
@@ -715,7 +721,11 @@ FMOD_RESULT AudioMan::UpdatePositionalEffectsForSoundChannel(FMOD::Channel* soun
 	if (!sceneWraps) {
 		wrappedChannelPositions = {channelPosition};
 	} else {
-		wrappedChannelPositions = (channelPosition.x <= halfSceneWidth) ? wrappedChannelPositions = {channelPosition, {channelPosition.x + g_SceneMan.GetSceneWidth(), channelPosition.y}} : wrappedChannelPositions = {FMOD_VECTOR({channelPosition.x - g_SceneMan.GetSceneWidth(), channelPosition.y}), channelPosition};
+		if (channelPosition.x <= halfSceneWidth) {
+			wrappedChannelPositions = {channelPosition, {channelPosition.x + g_SceneMan.GetSceneWidth(), channelPosition.y, 0.0}};
+		} else {
+			wrappedChannelPositions = {FMOD_VECTOR({channelPosition.x - g_SceneMan.GetSceneWidth(), channelPosition.y, 0.0}), channelPosition};
+		}
 	}
 
 	float sqrShortestDistance = c_SoundMaxAudibleDistance * c_SoundMaxAudibleDistance;
@@ -739,6 +749,9 @@ FMOD_RESULT AudioMan::UpdatePositionalEffectsForSoundChannel(FMOD::Channel* soun
 
 	int soundChannelIndex;
 	result = result == FMOD_OK ? soundChannel->getIndex(&soundChannelIndex) : result;
+	if (result != FMOD_OK) {
+		return result;
+	}
 
 	float attenuationStartDistance = c_DefaultAttenuationStartDistance;
 	float soundMaxDistance = 0.0F;
@@ -761,7 +774,7 @@ FMOD_RESULT AudioMan::UpdatePositionalEffectsForSoundChannel(FMOD::Channel* soun
 	float minimumAudibleDistance = m_SoundChannelMinimumAudibleDistances.at(soundChannelIndex);
 	if (shortestDistance >= soundMaxDistance) {
 		attenuatedVolume = 0.0F;
-	} else if (m_SoundChannelMinimumAudibleDistances.empty() || m_SoundChannelMinimumAudibleDistances.find(soundChannelIndex) == m_SoundChannelMinimumAudibleDistances.end()) {
+	} else if (m_SoundChannelMinimumAudibleDistances.find(soundChannelIndex) == m_SoundChannelMinimumAudibleDistances.end()) {
 		g_ConsoleMan.PrintString("ERROR: An error occurred when checking to see if the sound at channel " + std::to_string(soundChannelIndex) + " was less than its minimum audible distance away from the farthest listener.");
 	} else if (sqrLongestDistance < (minimumAudibleDistance * minimumAudibleDistance)) {
 		attenuatedVolume = 0.0F;
@@ -778,7 +791,7 @@ FMOD_RESULT AudioMan::UpdatePositionalEffectsForSoundChannel(FMOD::Channel* soun
 	return result;
 }
 
-FMOD_RESULT F_CALLBACK AudioMan::SoundChannelEndedCallback(FMOD_CHANNELCONTROL* channelControl, FMOD_CHANNELCONTROL_TYPE channelControlType, FMOD_CHANNELCONTROL_CALLBACK_TYPE callbackType, void* unusedCommandData1, void* unusedCommandData2) {
+FMOD_RESULT F_CALLBACK AudioMan::SoundChannelEndedCallback(FMOD_CHANNELCONTROL* channelControl, FMOD_CHANNELCONTROL_TYPE channelControlType, FMOD_CHANNELCONTROL_CALLBACK_TYPE callbackType, void*, void*) {
 	if (channelControlType == FMOD_CHANNELCONTROL_CHANNEL && callbackType == FMOD_CHANNELCONTROL_CALLBACK_END) {
 		FMOD::Channel* channel = reinterpret_cast<FMOD::Channel*>(channelControl);
 		int channelIndex;

--- a/Source/Managers/ConsoleMan.cpp
+++ b/Source/Managers/ConsoleMan.cpp
@@ -153,9 +153,8 @@ void ConsoleMan::AddLoadWarningLogExtensionMismatchEntry(const std::string& path
 		PrintString(newEntry);
 	} else {
 		std::transform(newEntry.begin(), newEntry.end(), newEntry.begin(), ::tolower);
-		if (m_LoadWarningLog.find(newEntry) == m_LoadWarningLog.end()) {
-			m_LoadWarningLog.emplace(newEntry);
-		}
+		// Emplace inserts only if there is no existing entry.
+		m_LoadWarningLog.emplace(newEntry);
 	}
 }
 

--- a/Source/Managers/LuaMan.cpp
+++ b/Source/Managers/LuaMan.cpp
@@ -105,7 +105,7 @@ void LuaStateWrapper::Initialize() {
 	                         luabind::def("LERP", (float (*)(float, float, float, float, float))&Lerp),
 	                         luabind::def("Lerp", (float (*)(float, float, float, float, float))&Lerp),
 	                         luabind::def("Lerp", (Vector(*)(float, float, Vector, Vector, float))&Lerp),
-	                         luabind::def("Lerp", (Matrix(*)(float, float, Matrix, Matrix, float))&Lerp),
+	                         luabind::def("Lerp", (Matrix(*)(float, float, const Matrix&, const Matrix&, float))&Lerp),
 	                         luabind::def("EaseIn", &EaseIn),
 	                         luabind::def("EaseOut", &EaseOut),
 	                         luabind::def("EaseInOut", &EaseInOut),

--- a/Source/Managers/MetaMan.cpp
+++ b/Source/Managers/MetaMan.cpp
@@ -314,7 +314,7 @@ void MetaMan::Destroy() {
 	Clear();
 }
 
-int MetaMan::SaveSceneData(std::string pathBase) {
+int MetaMan::SaveSceneData(const std::string& pathBase) {
 	for (std::vector<Scene*>::const_iterator sItr = m_Scenes.begin(); sItr != m_Scenes.end(); ++sItr) {
 		// Only save the data of revealed scenes that have already had their layers built and saved into files
 		if ((*sItr)->IsRevealed() && (*sItr)->GetTerrain() && (*sItr)->GetTerrain()->IsLoadedFromDisk()) {

--- a/Source/Managers/MetaMan.h
+++ b/Source/Managers/MetaMan.h
@@ -99,7 +99,7 @@ namespace RTE {
 		/// everything up to and including the unique name of the game.
 		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
-		int SaveSceneData(std::string pathBase);
+		int SaveSceneData(const std::string& pathBase);
 
 		/// Loads the bitmap data of all Scenes of this Metagame that have once
 		/// been saved to files.
@@ -123,12 +123,12 @@ namespace RTE {
 		/// Sets the name of the currently played Metagame. It's what's used when
 		/// saving to disk.
 		/// @param newName The Metagame's name.
-		void SetGameName(std::string newName) { m_GameName = newName; }
+		void SetGameName(std::string newName) { m_GameName = std::move(newName); }
 
 		/// Gets the name of the currently played Metagame. It's what's used when
 		/// saving to disk.
 		/// @return The name of the current metagame.
-		std::string GetGameName() const { return m_GameName; }
+		const std::string& GetGameName() const { return m_GameName; }
 
 		/// Gets the GUI controller of this Metagame.
 		/// @return The GUI controller of the metagame.

--- a/Source/Managers/MovableMan.cpp
+++ b/Source/Managers/MovableMan.cpp
@@ -27,11 +27,10 @@
 
 using namespace RTE;
 
-AlarmEvent::AlarmEvent(const Vector& pos, int team, float range) {
-	m_ScenePos = pos;
-	m_Team = (Activity::Teams)team;
-	m_Range = range * g_FrameMan.GetPlayerScreenWidth() * 0.51F;
-}
+AlarmEvent::AlarmEvent(const Vector& pos, int team, float range) :
+	m_ScenePos(pos),
+	m_Team((Activity::Teams)team),
+	m_Range(range * g_FrameMan.GetPlayerScreenWidth() * 0.51F) {}
 
 const std::string MovableMan::c_ClassName = "MovableMan";
 

--- a/Source/Managers/MusicMan.h
+++ b/Source/Managers/MusicMan.h
@@ -66,7 +66,7 @@ namespace RTE {
 
 		/// Gets the current DynamicSongSectionType being played.
 		/// @return The current DynamicSongSectionType being played.
-		std::string GetCurrentSongSectionType() const { return m_CurrentSongSectionType; }
+		const std::string& GetCurrentSongSectionType() const { return m_CurrentSongSectionType; }
 
 		/// Sets the current playing dynamic music to end, disabling further playback of new music.
 		/// @param fadeOutCurrent Whether to also fade out the current playing music or not.

--- a/Source/Managers/PresetMan.cpp
+++ b/Source/Managers/PresetMan.cpp
@@ -197,13 +197,13 @@ int PresetMan::GetModuleID(std::string moduleName) {
 		return (*itr).second;
 
 	// Try with or without the .rte on the end before giving up
-	int dotPos = moduleName.find_last_of('.');
+	size_t dotPos = moduleName.find_last_of('.');
 	// Wasnt, so try adding it
 	if (dotPos == std::string::npos)
 		moduleName = moduleName + System::GetModulePackageExtension();
 	// There was ".rte", so try to shave it off the name
 	else
-		moduleName = moduleName.substr(0, dotPos);
+		moduleName.resize(dotPos);
 
 	// Try to find the module again!
 	itr = m_DataModuleIDs.find(moduleName);
@@ -296,19 +296,19 @@ std::string PresetMan::GetFullModulePath(const std::string& modulePath) const {
 	return (pathTopDir == moduleTopDir) ? modulePathGeneric : moduleTopDir + modulePathGeneric;
 }
 
-bool PresetMan::AddEntityPreset(Entity* pEntToAdd, int whichModule, bool overwriteSame, std::string readFromFile) {
+bool PresetMan::AddEntityPreset(Entity* pEntToAdd, int whichModule, bool overwriteSame, const std::string& readFromFile) {
 	RTEAssert(whichModule >= 0 && whichModule < (int)m_pDataModules.size(), "Tried to access an out of bounds data module number!");
 
 	return m_pDataModules[whichModule]->AddEntityPreset(pEntToAdd, overwriteSame, readFromFile);
 }
 
-const Entity* PresetMan::GetEntityPreset(std::string type, std::string preset, int whichModule) {
+const Entity* PresetMan::GetEntityPreset(const std::string& type, std::string preset, int whichModule) {
 	RTEAssert(whichModule < (int)m_pDataModules.size(), "Tried to access an out of bounds data module number!");
 
 	const Entity* pRetEntity = 0;
 
 	// Preset name might have "[ModuleName]/" preceding it, detect it here and select proper module!
-	int slashPos = preset.find_first_of('/');
+	size_t slashPos = preset.find_first_of('/');
 	if (slashPos != std::string::npos) {
 		// Get the module ID and cut off the module specifier in the string
 		whichModule = GetModuleID(preset.substr(0, slashPos));
@@ -419,7 +419,7 @@ Entity* PresetMan::ReadReflectedPreset(Reader& reader) {
 	return 0;
 }
 
-bool PresetMan::GetAllOfType(std::list<Entity*>& entityList, std::string type, int whichModule) {
+bool PresetMan::GetAllOfType(std::list<Entity*>& entityList, const std::string& type, int whichModule) {
 	if (type.empty())
 		return false;
 
@@ -440,7 +440,7 @@ bool PresetMan::GetAllOfType(std::list<Entity*>& entityList, std::string type, i
 	return foundAny;
 }
 
-bool PresetMan::GetAllOfTypeInModuleSpace(std::list<Entity*>& entityList, std::string type, int whichModuleSpace) {
+bool PresetMan::GetAllOfTypeInModuleSpace(std::list<Entity*>& entityList, const std::string& type, int whichModuleSpace) {
 	if (type.empty())
 		return false;
 
@@ -497,7 +497,7 @@ bool PresetMan::GetAllNotOfGroups(std::list<Entity*>& entityList, const std::vec
 	return foundAny;
 }
 
-Entity* PresetMan::GetRandomOfGroup(std::string group, std::string type, int whichModule) {
+Entity* PresetMan::GetRandomOfGroup(std::string group, const std::string& type, int whichModule) {
 	RTEAssert(!group.empty(), "Looking for empty group!");
 
 	bool foundAny = false;
@@ -534,7 +534,7 @@ Entity* PresetMan::GetRandomOfGroup(std::string group, std::string type, int whi
 	return 0;
 }
 
-Entity* PresetMan::GetRandomBuyableOfGroupFromTech(std::string group, std::string type, int whichModule) {
+Entity* PresetMan::GetRandomBuyableOfGroupFromTech(std::string group, const std::string& type, int whichModule) {
 	RTEAssert(!group.empty(), "Looking for empty group!");
 
 	bool foundAny = false;
@@ -627,7 +627,7 @@ Entity* PresetMan::GetRandomBuyableOfGroupFromTech(std::string group, std::strin
 	return 0;
 }
 
-bool PresetMan::GetAllOfGroupInModuleSpace(std::list<Entity*>& entityList, std::string group, std::string type, int whichModuleSpace) {
+bool PresetMan::GetAllOfGroupInModuleSpace(std::list<Entity*>& entityList, const std::string& group, const std::string& type, int whichModuleSpace) {
 	RTEAssert(!group.empty(), "Looking for empty group!");
 
 	bool foundAny = false;
@@ -648,7 +648,7 @@ bool PresetMan::GetAllOfGroupInModuleSpace(std::list<Entity*>& entityList, std::
 	return foundAny;
 }
 
-Entity* PresetMan::GetRandomOfGroupInModuleSpace(std::string group, std::string type, int whichModuleSpace) {
+Entity* PresetMan::GetRandomOfGroupInModuleSpace(const std::string& group, const std::string& type, int whichModuleSpace) {
 	RTEAssert(!group.empty(), "Looking for empty group!");
 
 	bool foundAny = false;
@@ -685,7 +685,7 @@ Entity* PresetMan::GetRandomOfGroupInModuleSpace(std::string group, std::string 
 	return 0;
 }
 
-std::string PresetMan::GetEntityDataLocation(std::string type, std::string preset, int whichModule) {
+std::string PresetMan::GetEntityDataLocation(const std::string& type, const std::string& preset, int whichModule) {
 	RTEAssert(whichModule < (int)m_pDataModules.size(), "Tried to access an out of bounds data module number!");
 
 	std::string pRetPath = "";
@@ -754,7 +754,7 @@ bool PresetMan::ReloadEntityPreset(const std::string& presetName, const std::str
 
 	m_ReloadEntityPresetCalledThisUpdate = true;
 
-	Reader reader(presetDataLocation.c_str(), true);
+	Reader reader(presetDataLocation, true);
 	while (reader.NextProperty()) {
 		reader.ReadPropName();
 		g_PresetMan.GetEntityPreset(reader);
@@ -797,7 +797,7 @@ void PresetMan::RegisterGroup(std::string newGroup, int whichModule) {
 	m_pDataModules[whichModule]->RegisterGroup(newGroup);
 }
 
-bool PresetMan::GetGroups(std::list<std::string>& groupList, int whichModule, std::string withType) const {
+bool PresetMan::GetGroups(std::list<std::string>& groupList, int whichModule, const std::string& withType) const {
 	RTEAssert(whichModule < (int)m_pDataModules.size(), "Tried to access an out of bounds data module number!");
 
 	bool foundAny = false;
@@ -835,7 +835,7 @@ bool PresetMan::GetGroups(std::list<std::string>& groupList, int whichModule, st
 	return foundAny;
 }
 
-bool PresetMan::GetModuleSpaceGroups(std::list<std::string>& groupList, int whichModule, std::string withType) const {
+bool PresetMan::GetModuleSpaceGroups(std::list<std::string>& groupList, int whichModule, const std::string& withType) const {
 	RTEAssert(whichModule < (int)m_pDataModules.size(), "Tried to access an out of bounds data module number!");
 
 	bool foundAny = false;

--- a/Source/Managers/PresetMan.h
+++ b/Source/Managers/PresetMan.h
@@ -68,7 +68,7 @@ namespace RTE {
 
 		/// Sets the single module to be loaded after the official modules. This will be the ONLY non-official module to be loaded.
 		/// @param moduleName Name of the module to load.
-		void SetSingleModuleToLoad(std::string moduleName) { m_SingleModuleToLoad = moduleName; }
+		void SetSingleModuleToLoad(std::string moduleName) { m_SingleModuleToLoad = std::move(moduleName); }
 
 		/// Gets a specific loaded DataModule
 		/// @param whichModule The ID of the module to get. (default: 0)
@@ -134,7 +134,7 @@ namespace RTE {
 		/// @return Whether or not a copy of the passed-in instance was successfully inserted
 		/// into the module. False will be returned if there already was an instance
 		/// of that class and instance name inserted previously, unless overwritten.
-		bool AddEntityPreset(Entity* pEntToAdd, int whichModule = 0, bool overwriteSame = false, std::string readFromFile = "Same");
+		bool AddEntityPreset(Entity* pEntToAdd, int whichModule = 0, bool overwriteSame = false, const std::string& readFromFile = "Same");
 
 		/// Gets a previously read in (defined) Entity, by type and instance name.
 		/// @param type The type name of the derived Entity. Ownership is NOT transferred!
@@ -143,9 +143,9 @@ namespace RTE {
 		/// the official modules will be searched also. -1 means search ALL modules!
 		/// @return A pointer to the requested Entity instance. 0 if no Entity with that
 		/// derived type or instance name was found. Ownership is NOT transferred!
-		const Entity* GetEntityPreset(std::string type, std::string preset, int whichModule = -1);
+		const Entity* GetEntityPreset(const std::string& type, std::string preset, int whichModule = -1);
 		// Helper for passing in string module name instead of ID
-		const Entity* GetEntityPreset(std::string type, std::string preset, std::string module) { return GetEntityPreset(type, preset, GetModuleID(module)); }
+		const Entity* GetEntityPreset(const std::string& type, std::string preset, std::string module) { return GetEntityPreset(type, std::move(preset), GetModuleID(std::move(module))); }
 
 		/// Reads an instance of an Entity that will be used as preset
 		/// to later on be used to generate more instances of the same state.
@@ -173,7 +173,7 @@ namespace RTE {
 		/// @param whichModule The type name of the Entitys you want. (default: -1)
 		/// Whether to only get those of one specific DataModule (0-n), or all (-1).
 		/// @return Whether any Entity:s were found and added to the list.
-		bool GetAllOfType(std::list<Entity*>& entityList, std::string type, int whichModule = -1);
+		bool GetAllOfType(std::list<Entity*>& entityList, const std::string& type, int whichModule = -1);
 
 		/// Adds to a list all previously read in (defined) Entitys which are
 		/// of a specific type, and only exist in a specific module space.
@@ -184,7 +184,7 @@ namespace RTE {
 		/// official modules loaded earlier than the one specified here. -1 means
 		/// get ALL groups ever reg'd.
 		/// @return Whether any Entity:s were found and added to the list.
-		bool GetAllOfTypeInModuleSpace(std::list<Entity*>& entityList, std::string type, int whichModuleSpace);
+		bool GetAllOfTypeInModuleSpace(std::list<Entity*>& entityList, const std::string& type, int whichModuleSpace);
 
 		/// Adds to a list all previously read in (defined) Entities which are associated with a specific group.
 		/// @param entityList Reference to a list which will get all matching Entities added to it. Ownership of the list or the Entities placed in it are NOT transferred!
@@ -225,7 +225,7 @@ namespace RTE {
 		/// "All" will look at all types.
 		/// @param whichModule Whether to only get those of one specific DataModule (0-n), or all (-1). (default: -1)
 		/// @return The Entity preset that was randomly selected. Ownership is NOT transferred!
-		Entity* GetRandomOfGroup(std::string group, std::string type = "All", int whichModule = -1);
+		Entity* GetRandomOfGroup(std::string group, const std::string& type = "All", int whichModule = -1);
 
 		/// Returns a previously read in (defined) Entity which is randomly
 		/// selected from a specific group only if it belongs to some tech.
@@ -235,7 +235,7 @@ namespace RTE {
 		/// @param whichModule Whether to only get those of one specific DataModule (0-n), or all (-1) (default: -1)
 		/// or all modules uncluding non-tech ones.
 		/// @return The Entity preset that was randomly selected. Ownership is NOT transferred!
-		Entity* GetRandomBuyableOfGroupFromTech(std::string group, std::string type = "All", int whichModule = -1);
+		Entity* GetRandomBuyableOfGroupFromTech(std::string group, const std::string& type = "All", int whichModule = -1);
 
 		/// Adds to a list all previously read in (defined) Entitys which are
 		/// associated with a specific group, and only exist in a specific module
@@ -249,7 +249,7 @@ namespace RTE {
 		/// official modules loaded earlier than the one specified here. -1 means
 		/// get ALL groups ever reg'd.
 		/// @return Whether any Entity:s were found and added to the list.
-		bool GetAllOfGroupInModuleSpace(std::list<Entity*>& entityList, std::string group, std::string type, int whichModuleSpace);
+		bool GetAllOfGroupInModuleSpace(std::list<Entity*>& entityList, const std::string& group, const std::string& type, int whichModuleSpace);
 
 		/// Returns a previously read in (defined) Entity which is associated with
 		/// a specific group, randomly selected and only exist in a specific module
@@ -263,7 +263,7 @@ namespace RTE {
 		/// get ALL groups ever reg'd.
 		/// @return The randomly select preset, if any was found with thse search params.
 		/// Ownership is NOT transferred!
-		Entity* GetRandomOfGroupInModuleSpace(std::string group, std::string type, int whichModuleSpace);
+		Entity* GetRandomOfGroupInModuleSpace(const std::string& group, const std::string& type, int whichModuleSpace);
 
 		/// Gets the data file path of a previously read in (defined) Entity.
 		/// @param type The type name of the derived Entity. Ownership is NOT transferred!
@@ -272,7 +272,7 @@ namespace RTE {
 		/// the official modules will be searched also.
 		/// @return The file path of the data file that the specified Entity was read from.
 		/// If no Entity of that description was found, "" is returned.
-		std::string GetEntityDataLocation(std::string type, std::string preset, int whichModule);
+		std::string GetEntityDataLocation(const std::string& type, const std::string& preset, int whichModule);
 
 		/// Reloads all scripted Entity Presets with the latest version of their respective script files.
 		void ReloadAllScripts() const;
@@ -323,7 +323,7 @@ namespace RTE {
 		/// @param withType Pass a type name here and only groups with entitys of that type will be (default: "All")
 		/// be included. "All" means don't consider what types are in the groups.
 		/// @return Whether any groups were found and thus added to the list.
-		bool GetGroups(std::list<std::string>& groupList, int whichModule = -1, std::string withType = "All") const;
+		bool GetGroups(std::list<std::string>& groupList, int whichModule = -1, const std::string& withType = "All") const;
 
 		/// Fills out a list with all groups registered in all official modules,
 		/// PLUS a specific non-official module as well.
@@ -334,7 +334,7 @@ namespace RTE {
 		/// @param withType Pass a type name here and only groups with entitys of that type will be (default: "All")
 		/// be included. "All" means don't consider what types are in the groups.
 		/// @return Whether any groups were found and thus added to the list.
-		bool GetModuleSpaceGroups(std::list<std::string>& groupList, int whichModule, std::string withType = "All") const;
+		bool GetModuleSpaceGroups(std::list<std::string>& groupList, int whichModule, const std::string& withType = "All") const;
 
 		/// Creates and returns actor defined in the specified loadout.
 		/// @param loadoutName Loadout preset name, module name, whether or not spawn delivery craft defined for that loadout

--- a/Source/Managers/SceneMan.cpp
+++ b/Source/Managers/SceneMan.cpp
@@ -86,7 +86,7 @@ void SceneMan::Initialize() const {
 	    {512, create_bitmap_ex(8, 512, 512)}};
 }
 
-int SceneMan::Create(std::string readerFile) {
+int SceneMan::Create(const std::string& readerFile) {
 	Reader* reader = new Reader();
 	if (reader->Create(readerFile.c_str()))
 		g_ConsoleMan.PrintString("ERROR: Could not find Scene definition file!");
@@ -171,7 +171,7 @@ int SceneMan::LoadScene(Scene* pNewScene, bool placeObjects, bool placeUnits) {
 	return 0;
 }
 
-int SceneMan::SetSceneToLoad(std::string sceneName, bool placeObjects, bool placeUnits) {
+int SceneMan::SetSceneToLoad(const std::string& sceneName, bool placeObjects, bool placeUnits) {
 	// Use the name passed in to load the preset requested
 	const Scene* pSceneRef = dynamic_cast<const Scene*>(g_PresetMan.GetEntityPreset("Scene", sceneName));
 
@@ -203,7 +203,7 @@ int SceneMan::LoadScene() {
 	return LoadScene(dynamic_cast<Scene*>(m_pSceneToLoad->Clone()), m_PlaceObjects, m_PlaceUnits);
 }
 
-int SceneMan::LoadScene(std::string sceneName, bool placeObjects, bool placeUnits) {
+int SceneMan::LoadScene(const std::string& sceneName, bool placeObjects, bool placeUnits) {
 	// First retrieve and set up the preset reference
 	int error = SetSceneToLoad(sceneName, placeObjects, placeUnits);
 	if (error < 0)
@@ -897,7 +897,7 @@ void SceneMan::MakeAllUnseen(Vector pixelSize, const int team) {
 	m_pCurrentScene->FillUnseenLayer(pixelSize, team);
 }
 
-bool SceneMan::LoadUnseenLayer(std::string bitmapPath, int team) {
+bool SceneMan::LoadUnseenLayer(const std::string& bitmapPath, int team) {
 	ContentFile bitmapFile(bitmapPath.c_str());
 	SceneLayer* pUnseenLayer = new SceneLayer();
 	if (pUnseenLayer->Create(bitmapFile.GetAsBitmap(COLORCONV_NONE, false), true, Vector(), m_pCurrentScene->WrapsX(), m_pCurrentScene->WrapsY(), Vector(1.0, 1.0)) < 0) {

--- a/Source/Managers/SceneMan.h
+++ b/Source/Managers/SceneMan.h
@@ -69,26 +69,26 @@ namespace RTE {
 		/// Makes the SceneMan object ready for use.
 		/// @param readerFile A string with the filepath to a Reader file from screen this SceneMan's
 		/// data should be created.
-		/// @return An error return value signaling sucess or any particular failure.
+		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
-		int Create(std::string readerFile);
+		int Create(const std::string& readerFile);
 
 		/// Sets the instance name of the default Scene to be loaded if nothing
 		/// else is available.
 		/// @param defaultSceneName The default scene instance name.
-		void SetDefaultSceneName(std::string defaultSceneName) { m_DefaultSceneName = defaultSceneName; }
+		void SetDefaultSceneName(std::string defaultSceneName) { m_DefaultSceneName = std::move(defaultSceneName); }
 
 		/// Gets the name of the default A to be loaded if nothing
 		/// else is available.
 		/// @return The default Scene instance name.
-		std::string GetDefaultSceneName() const { return m_DefaultSceneName; }
+		const std::string& GetDefaultSceneName() const { return m_DefaultSceneName; }
 
 		/// Actually loads a new Scene into memory. has to be done before using
 		/// this object.
 		/// @param pNewScene The instance of the Scene, ownership IS transferred!
 		/// @param placeObjects Whether the scene should actually apply all its SceneObject:s placed (default: true)
 		/// in its definition.
-		/// @return An error return value signaling sucess or any particular failure.
+		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
 		int LoadScene(Scene* pNewScene, bool placeObjects = true, bool placeUnits = true);
 
@@ -106,9 +106,9 @@ namespace RTE {
 		/// @param sceneName The name of the Scene preset instance to load.
 		/// @param placeObjects Whether the scene should actually apply all its SceneObject:s placed (default: true)
 		/// in its definition.
-		/// @return An error return value signaling sucess or any particular failure.
+		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
-		int SetSceneToLoad(std::string sceneName, bool placeObjects = true, bool placeUnits = true);
+		int SetSceneToLoad(const std::string& sceneName, bool placeObjects = true, bool placeUnits = true);
 
 		/// Gets the stored Scene reference to be loaded later into the SceneMan.
 		/// @return The instance reference of the Scene, ownership IS NOT (!!) transferred!
@@ -123,7 +123,7 @@ namespace RTE {
 		bool GetPlaceUnitsOnLoad() const { return m_PlaceUnits; }
 
 		/// Actually loads the Scene set to be loaded in SetSceneToLoad.
-		/// @return An error return value signaling sucess or any particular failure.
+		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
 		int LoadScene();
 
@@ -132,17 +132,17 @@ namespace RTE {
 		/// @param placeObjects Whether the scene should actually apply all its SceneObject:s placed (default: true)
 		/// in its definition.
 		/// @param placeUnits Whether the scene should actually deploy all units placed in its definition. (default: true)
-		/// @return An error return value signaling sucess or any particular failure.
+		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
-		int LoadScene(std::string sceneName, bool placeObjects = true, bool placeUnits = true);
+		int LoadScene(const std::string& sceneName, bool placeObjects = true, bool placeUnits = true);
 
 		/// Loads a Scene right now, by preset name.
 		/// @param sceneName The name of the Scene preset instance to load.
 		/// @param placeObjects Whether the scene should actually apply all its SceneObject:s placed (default: true) { return LoadScene(sceneName)
 		/// in its definition.
-		/// @return An error return value signaling sucess or any particular failure.
+		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
-		int LoadScene(std::string sceneName, bool placeObjects = true) { return LoadScene(sceneName, placeObjects, true); }
+		int LoadScene(const std::string& sceneName, bool placeObjects = true) { return LoadScene(sceneName, placeObjects, true); }
 
 		/// Resets the entire SceneMan, including its inherited members, to
 		/// their default settings or values.
@@ -440,7 +440,7 @@ namespace RTE {
 		/// @param bitmapPath The path to the bitmap to use as the unseen layer.
 		/// @param team Which team we're talking about.
 		/// @return Whether the loading was successful or not.
-		bool LoadUnseenLayer(std::string bitmapPath, const int team);
+		bool LoadUnseenLayer(const std::string& bitmapPath, const int team);
 
 		/// Tells whether a team has anything still unseen on the scene.
 		/// @param team The team we're talking about.

--- a/Source/Managers/SettingsMan.h
+++ b/Source/Managers/SettingsMan.h
@@ -203,7 +203,7 @@ namespace RTE {
 #pragma region Network Settings
 		/// Gets the player name that is used in network multiplayer matches.
 		/// @return String with the network player name.
-		std::string GetPlayerNetworkName() const { return m_PlayerNetworkName; }
+		const std::string& GetPlayerNetworkName() const { return m_PlayerNetworkName; }
 
 		/// Sets the player name that will be used in network multiplayer matches.
 		/// @param newName String with the new player name to use.
@@ -211,7 +211,7 @@ namespace RTE {
 
 		/// Gets the LAN server address to connect to.
 		/// @return The current LAN server address to connect to.
-		std::string GetNetworkServerAddress() const { return m_NetworkServerAddress; }
+		const std::string& GetNetworkServerAddress() const { return m_NetworkServerAddress; }
 
 		/// Sets the LAN server address to connect to.
 		/// @param newName New LAN server address to connect to.
@@ -219,7 +219,7 @@ namespace RTE {
 
 		/// Gets the NAT punch-through server address.
 		/// @return The current NAT punch-through server address to connect to.
-		std::string& GetNATServiceAddress() { return m_NATServiceAddress; }
+		const std::string& GetNATServiceAddress() { return m_NATServiceAddress; }
 
 		/// Sets the NAT punch-through server address.
 		/// @param newValue New NAT punch-through server address to connect to.
@@ -227,7 +227,7 @@ namespace RTE {
 
 		/// Gets the server name used when connecting via NAT punch-through service.
 		/// @return Name of the NAT punch-through server.
-		std::string& GetNATServerName() { return m_NATServerName; }
+		const std::string& GetNATServerName() { return m_NATServerName; }
 
 		/// Sets the server name to use when connecting via NAT punch-through service.
 		/// @param newValue New NAT punch-through server name.
@@ -235,7 +235,7 @@ namespace RTE {
 
 		/// Gets the server password to use when connecting via NAT punch-through service.
 		/// @return The server password to use when connecting via NAT punch-through service.
-		std::string& GetNATServerPassword() { return m_NATServerPassword; }
+		const std::string& GetNATServerPassword() { return m_NATServerPassword; }
 
 		/// Sets the server password to use when connecting via NAT punch-through service.
 		/// @param newValue New password to use when connecting via NAT punch-through service.
@@ -253,7 +253,7 @@ namespace RTE {
 #pragma region Editor Settings
 		/// Returns the list of visible assembly groups.
 		/// @return List of visible assembly groups.
-		std::list<std::string> GetVisibleAssemblyGroupsList() const { return m_VisibleAssemblyGroupsList; }
+		const std::list<std::string>& GetVisibleAssemblyGroupsList() const { return m_VisibleAssemblyGroupsList; }
 
 		/// Whether editors will allow to select Base.rte as a module to save in
 		/// @return True of editors are allowed to select Base.rte as a module to save in.

--- a/Source/Menus/AreaEditorGUI.cpp
+++ b/Source/Menus/AreaEditorGUI.cpp
@@ -120,7 +120,7 @@ void AreaEditorGUI::SetCurrentArea(Scene::Area* pArea) {
 	}
 }
 
-void AreaEditorGUI::UpdatePickerList(std::string selectAreaName) {
+void AreaEditorGUI::UpdatePickerList(const std::string& selectAreaName) {
 	m_pPicker->UpdateAreasList(selectAreaName);
 }
 

--- a/Source/Menus/AreaEditorGUI.h
+++ b/Source/Menus/AreaEditorGUI.h
@@ -107,7 +107,7 @@ namespace RTE {
 		/// Updates the list that the GUI's Area picker has, from the current
 		/// scene state.
 		/// @param selectAreaName The name of the Area to leave selected after the list is updated. (default: "")
-		void UpdatePickerList(std::string selectAreaName = "");
+		void UpdatePickerList(const std::string& selectAreaName = "");
 
 		/// Updates the state of this Menu each frame
 		void Update();

--- a/Source/Menus/AreaPickerGUI.cpp
+++ b/Source/Menus/AreaPickerGUI.cpp
@@ -53,7 +53,7 @@ void AreaPickerGUI::Clear() {
 	m_CursorPos.Reset();
 }
 
-int AreaPickerGUI::Create(Controller* pController, std::string onlyOfType) {
+int AreaPickerGUI::Create(Controller* pController, const std::string& onlyOfType) {
 	RTEAssert(pController, "No controller sent to AreaPickerGUI on creation!");
 	m_pController = pController;
 
@@ -77,7 +77,7 @@ int AreaPickerGUI::Create(Controller* pController, std::string onlyOfType) {
 	// Stretch the invisible root box to fill the screen
 	dynamic_cast<GUICollectionBox*>(m_pGUIController->GetControl("base"))->SetSize(g_WindowMan.GetResX(), g_WindowMan.GetResY());
 
-	// Make sure we have convenient points to teh containing GUI colleciton boxes that we will manipulate the positions of
+	// Make sure we have convenient points to the containing GUI colleciton boxes that we will manipulate the positions of
 	if (!m_pParentBox) {
 		m_pParentBox = dynamic_cast<GUICollectionBox*>(m_pGUIController->GetControl("PickerGUIBox"));
 
@@ -194,7 +194,7 @@ Scene::Area* AreaPickerGUI::GetPrevArea() {
 	return 0;
 }
 
-void AreaPickerGUI::UpdateAreasList(std::string selectAreaName) {
+void AreaPickerGUI::UpdateAreasList(const std::string& selectAreaName) {
 	m_pAreasList->ClearList();
 
 	if (g_SceneMan.GetScene() && !g_SceneMan.GetScene()->m_AreaList.empty()) {

--- a/Source/Menus/AreaPickerGUI.h
+++ b/Source/Menus/AreaPickerGUI.h
@@ -37,12 +37,12 @@ namespace RTE {
 		~AreaPickerGUI();
 
 		/// Makes the AreaPickerGUI area ready for use.
-		/// @param pController A poitner to a Controller which will control this Menu. Ownership is
+		/// @param pController A pointer to a Controller which will control this Menu. Ownership is
 		/// @param onlyOfType NOT TRANSFERRED! (default: "All")
 		/// Which lowest common denominator type to be showing.
-		/// @return An error return value signaling sucess or any particular failure.
+		/// @return An error return value signaling success or any particular failure.
 		/// Anything below 0 is an error signal.
-		int Create(Controller* pController, std::string onlyOfType = "All");
+		int Create(Controller* pController, const std::string& onlyOfType = "All");
 
 		/// Resets the entire AreaPickerGUI, including its inherited members, to
 		/// their default settings or values.
@@ -98,7 +98,7 @@ namespace RTE {
 
 		/// Adds all areas of the currently selected group to the Areas list.
 		/// @param selectAreaName The name of the Area to leave selected after the list is updated. (default: "")
-		void UpdateAreasList(std::string selectAreaName = "");
+		void UpdateAreasList(const std::string& selectAreaName = "");
 
 		/// Updates the state of this Menu each frame
 		void Update();

--- a/Source/Menus/AssemblyEditorGUI.h
+++ b/Source/Menus/AssemblyEditorGUI.h
@@ -152,11 +152,11 @@ namespace RTE {
 
 		/// Returns the name of currently edited assembly
 		/// @return Name of currently edited assembly.
-		std::string GetCurrentAssemblyName() { return m_CurrentAssemblyName; }
+		const std::string& GetCurrentAssemblyName() { return m_CurrentAssemblyName; }
 
 		/// Sets new name of currently edited assembly
 		/// @param newName New name for assembly.
-		void SetCurrentAssemblyName(std::string newName) { m_CurrentAssemblyName = newName; }
+		void SetCurrentAssemblyName(std::string newName) { m_CurrentAssemblyName = std::move(newName); }
 
 		/// Protected member variable and method declarations
 	protected:

--- a/Source/Menus/BuyMenuGUI.h
+++ b/Source/Menus/BuyMenuGUI.h
@@ -198,11 +198,11 @@ namespace RTE {
 		/// If the list is not empty then everything not in the list is removed from the buy menu
 		/// Items will be removed from the buy menu when it's called, category changed or after a ForceRefresh().
 		/// @param presetName Full preset name to add.
-		void AddAllowedItem(std::string presetName) { m_AllowedItems[presetName] = true; };
+		void AddAllowedItem(std::string presetName) { m_AllowedItems[std::move(presetName)] = true; };
 
 		/// Removes an item from the list of allowed items.
 		/// @param m_AllowedItems.erase(presetName Full preset name to remove.
-		void RemoveAllowedItem(std::string presetName) { m_AllowedItems.erase(presetName); };
+		void RemoveAllowedItem(const std::string& presetName) { m_AllowedItems.erase(presetName); };
 
 		/// Clears the list of allowed items
 		void ClearAllowedItems() { m_AllowedItems.clear(); };
@@ -213,11 +213,11 @@ namespace RTE {
 
 		/// Adds an item to the list of always allowed items. This list overrides all previous constraints.
 		/// @param presetName Full preset name to add.
-		void AddAlwaysAllowedItem(std::string presetName) { m_AlwaysAllowedItems[presetName] = true; };
+		void AddAlwaysAllowedItem(std::string presetName) { m_AlwaysAllowedItems[std::move(presetName)] = true; };
 
 		/// Removes an item from the list of always allowed items.
 		/// @param m_AlwaysAllowedItems.erase(presetName Full preset name to remove.
-		void RemoveAlwaysAllowedItem(std::string presetName) { m_AlwaysAllowedItems.erase(presetName); };
+		void RemoveAlwaysAllowedItem(const std::string& presetName) { m_AlwaysAllowedItems.erase(presetName); };
 
 		/// Clears the list of allowed items
 		void ClearAlwaysAllowedItems() { m_AlwaysAllowedItems.clear(); };
@@ -229,11 +229,11 @@ namespace RTE {
 		/// Adds an item prohibited to buy from the buy menu.
 		/// The item will be removed from the buy menu when it's called, category changed or after a ForceRefresh().
 		/// @param presetName Full preset name to add.
-		void AddProhibitedItem(std::string presetName) { m_ProhibitedItems[presetName] = true; };
+		void AddProhibitedItem(std::string presetName) { m_ProhibitedItems[std::move(presetName)] = true; };
 
 		/// Removes item from the list of prohibited items
 		/// @param m_ProhibitedItems.erase(presetName Full preset name to remove.
-		void RemoveProhibitedItem(std::string presetName) { m_ProhibitedItems.erase(presetName); };
+		void RemoveProhibitedItem(const std::string& presetName) { m_ProhibitedItems.erase(presetName); };
 
 		/// Clears the list of prohibited items
 		void ClearProhibitedItems() { m_ProhibitedItems.clear(); };
@@ -273,7 +273,7 @@ namespace RTE {
 
 		/// Sets the amount of specified items to be owned in this buy menu
 		/// @param presetName Full preset name of item to own. Amount of owned items.
-		void SetOwnedItemsAmount(std::string presetName, int amount) { m_OwnedItems[presetName] = amount; };
+		void SetOwnedItemsAmount(std::string presetName, int amount) { m_OwnedItems[std::move(presetName)] = amount; };
 
 		/// Returns the amount of specified items owned in this buy menu
 		/// @param presetName Full preset name of item.

--- a/Source/Menus/InventoryMenuGUI.cpp
+++ b/Source/Menus/InventoryMenuGUI.cpp
@@ -1421,7 +1421,7 @@ void InventoryMenuGUI::DrawCarouselItemBoxForeground(const CarouselItemBox& item
 	});
 
 	std::string massString = totalItemMass < 0.1F ? "<0.1 kg" : RoundFloatToPrecision(std::fminf(999, totalItemMass), (totalItemMass < 9.95F ? 1 : 0)) + (totalItemMass > 999 ? "+ " : " ") + "kg";
-	m_SmallFont->DrawAligned(carouselAllegroBitmap, itemBoxToDraw.IconCenterPosition.GetFloorIntX(), itemBoxToDraw.IconCenterPosition.GetFloorIntY() - ((itemBoxToDraw.CurrentSize.GetFloorIntY() + m_SmallFont->GetFontHeight()) / 2) + 1, massString.c_str(), GUIFont::Centre);
+	m_SmallFont->DrawAligned(carouselAllegroBitmap, itemBoxToDraw.IconCenterPosition.GetFloorIntX(), itemBoxToDraw.IconCenterPosition.GetFloorIntY() - ((itemBoxToDraw.CurrentSize.GetFloorIntY() + m_SmallFont->GetFontHeight()) / 2) + 1, massString, GUIFont::Centre);
 }
 
 void InventoryMenuGUI::DrawFullMode(BITMAP* targetBitmap, const Vector& drawPos) const {

--- a/Source/Menus/MetagameGUI.cpp
+++ b/Source/Menus/MetagameGUI.cpp
@@ -799,7 +799,7 @@ void MetagameGUI::SelectScene(Scene* pScene) {
 	}
 }
 
-bool MetagameGUI::SelectScene(std::string sceneName) {
+bool MetagameGUI::SelectScene(const std::string& sceneName) {
 	for (std::vector<Scene*>::iterator sItr = g_MetaMan.m_Scenes.begin(); sItr != g_MetaMan.m_Scenes.end(); ++sItr) {
 		// Only allow selection if the Scene is revealed yet!
 		if ((*sItr)->GetPresetName() == sceneName && (*sItr)->IsRevealed()) {
@@ -1089,7 +1089,7 @@ bool MetagameGUI::LoadGame() {
 	return false;
 }
 
-bool MetagameGUI::SaveGame(std::string saveName, std::string savePath, bool resaveSceneData) {
+bool MetagameGUI::SaveGame(const std::string& saveName, const std::string& savePath, bool resaveSceneData) {
 	const std::string fullSavePath = g_PresetMan.GetFullModulePath(savePath);
 	// If specified, first load all bitmap data of all Scenes in the current Metagame that have once saved em, so we can re-save them to the new files
 	if (resaveSceneData)
@@ -1103,7 +1103,7 @@ bool MetagameGUI::SaveGame(std::string saveName, std::string savePath, bool resa
 	g_MetaMan.SaveSceneData(METASAVEPATH + saveName);
 
 	// Whichever new or existing, create a writer with the path
-	Writer metaWriter(fullSavePath.c_str());
+	Writer metaWriter(fullSavePath);
 	// Now that all the updated data files have been written to disk and their paths updated, send the MetaMan state for actual writing to an ini
 	if (g_MetaMan.Save(metaWriter) < 0)
 		return false;
@@ -5594,7 +5594,7 @@ void MetagameGUI::UpdatePlayerBars() {
 	}
 }
 
-void MetagameGUI::UpdateSiteNameLabel(bool visible, std::string text, const Vector& location, float height) {
+void MetagameGUI::UpdateSiteNameLabel(bool visible, const std::string& text, const Vector& location, float height) {
 	// Set up the hover label to appear over any hovered scene location
 	m_pScenePlanetLabel->SetVisible(visible);
 	if (visible) {
@@ -5617,7 +5617,7 @@ void MetagameGUI::UpdateSiteNameLabel(bool visible, std::string text, const Vect
 	}
 }
 
-void MetagameGUI::PlayerTextIndication(int metaPlayer, std::string text, const Vector& screenPos, double animLengthMS) {
+void MetagameGUI::PlayerTextIndication(int metaPlayer, const std::string& text, const Vector& screenPos, double animLengthMS) {
 	m_apFundsChangeLabel[metaPlayer]->SetText(text);
 	m_apFundsChangeLabel[metaPlayer]->SetHAlignment(GUIFont::Centre);
 	m_apFundsChangeLabel[metaPlayer]->SetVAlignment(GUIFont::Middle);

--- a/Source/Menus/MetagameGUI.h
+++ b/Source/Menus/MetagameGUI.h
@@ -80,20 +80,20 @@ namespace RTE {
 			         int onlyLastSegments = -1,
 			         int channelHeight = 60,
 			         float circleSize = 1.0f,
-			         bool squareSite = false) {
-				m_Player = player;
-				m_StartMeterAt = startMeterAt;
-				m_MeterAmount = meterAmount;
-				m_PlanetPoint = planetPoint;
-				m_SiteName = siteName;
-				m_pScene = pScene;
-				m_Color = color;
-				m_OnlyFirstSegments = onlyFirstSegments;
-				m_OnlyLastSegments = onlyLastSegments;
-				m_ChannelHeight = channelHeight;
-				m_CircleSize = circleSize;
-				m_Square = squareSite;
-			}
+			         bool squareSite = false) :
+
+				m_Player(player),
+				m_StartMeterAt(startMeterAt),
+				m_MeterAmount(meterAmount),
+				m_PlanetPoint(planetPoint),
+				m_SiteName(std::move(siteName)),
+				m_pScene(pScene),
+				m_Color(color),
+				m_OnlyFirstSegments(onlyFirstSegments),
+				m_OnlyLastSegments(onlyLastSegments),
+				m_ChannelHeight(channelHeight),
+				m_CircleSize(circleSize),
+				m_Square(squareSite) {}
 		};
 
 		// For storing info about target crosshairs over sites
@@ -128,14 +128,14 @@ namespace RTE {
 			           float animProgress,
 			           int style,
 			           int color,
-			           double startTime = 0) {
-				m_CenterPos = centerPos;
-				m_AnimProgress = animProgress;
-				m_Style = style;
-				m_Color = color;
-				m_StartTime = startTime;
-				m_AnimTimer.Reset();
-			}
+			           double startTime = 0) :
+				m_CenterPos(centerPos),
+				m_AnimProgress(animProgress),
+				m_Style(style),
+				m_Color(color),
+				m_StartTime(startTime) {
+					m_AnimTimer.Reset();
+				}
 
 			/// Draws this SiteTarget onto a bitmap of choice.
 			/// @param drawBitmap The bitmap to draw to.
@@ -200,7 +200,7 @@ namespace RTE {
 		/// Tries to select a specifically named scene on the metagame field.
 		/// @param sceneName The name of the Scene to try to find and select.
 		/// @return Whether mission was found and selected.
-		bool SelectScene(std::string sceneName);
+		bool SelectScene(const std::string& sceneName);
 
 		/// Reports whether the player has decided to continue to next phase of the
 		/// round of the current game.
@@ -241,7 +241,7 @@ namespace RTE {
 		/// @param resaveSceneData Whether to load all the scene data that is on disk first so it will (default: false)
 		/// be re-saved to the new location here.
 		/// @return Whether the game was able to be saved there.
-		bool SaveGame(std::string saveName, std::string savePath, bool resaveSceneData = false);
+		bool SaveGame(const std::string& saveName, const std::string& savePath, bool resaveSceneData = false);
 
 		/// Attempts to save a Metagame to disk using the settings set in the
 		/// Save Game dialog box.
@@ -405,7 +405,7 @@ namespace RTE {
 		/// @param text Text to show above the location. (default: "")
 		/// @param location The location in planetary coords. (default: Vector())
 		/// @param height How high above the location to show the text, adjustment from a good default. (default: 1.0)
-		void UpdateSiteNameLabel(bool visible, std::string text = "", const Vector& location = Vector(), float height = 1.0);
+		void UpdateSiteNameLabel(bool visible, const std::string& text = "", const Vector& location = Vector(), float height = 1.0);
 
 		/// Starts an animation of a label showing a text string over a player bar
 		/// @param player Which player the indication is relevant to
@@ -413,7 +413,7 @@ namespace RTE {
 		/// @param screenPos Where, in screen coords the change should be indicated. The CENTER of
 		/// the floating label will line up with this pos.
 		/// @param animLengthMS How long, in MS, that the animation should linger
-		void PlayerTextIndication(int player, std::string text, const Vector& screenPos, double animLengthMS);
+		void PlayerTextIndication(int player, const std::string& text, const Vector& screenPos, double animLengthMS);
 
 		/// Starts an animation of a label showing funds changing for a player
 		/// @param player Which player the change is relevant to

--- a/Source/Menus/ScenarioActivityConfigGUI.h
+++ b/Source/Menus/ScenarioActivityConfigGUI.h
@@ -70,7 +70,7 @@ namespace RTE {
 		Scene* m_SelectedScene; //!< The Scene the selected Activity will be using.
 		int m_LockedCPUTeam = Activity::Teams::NoTeam; //!< Which team the CPU is locked to, if any.
 
-		bool m_StartingGoldAdjustedManually { false }; //!< Whether the player adjusted the starting gold, meaning it should stop automatically adjusting to the difficulty setting default starting gold where applicable.
+		bool m_StartingGoldAdjustedManually {}; //!< Whether the player adjusted the starting gold, meaning it should stop automatically adjusting to the difficulty setting default starting gold where applicable.
 
 		Timer m_StartGameButtonBlinkTimer; //!< Timer for blinking the start game button.
 

--- a/Source/Menus/ScenarioActivityConfigGUI.h
+++ b/Source/Menus/ScenarioActivityConfigGUI.h
@@ -70,7 +70,7 @@ namespace RTE {
 		Scene* m_SelectedScene; //!< The Scene the selected Activity will be using.
 		int m_LockedCPUTeam = Activity::Teams::NoTeam; //!< Which team the CPU is locked to, if any.
 
-		bool m_StartingGoldAdjustedManually; //!< Whether the player adjusted the starting gold, meaning it should stop automatically adjusting to the difficulty setting default starting gold where applicable.
+		bool m_StartingGoldAdjustedManually { false }; //!< Whether the player adjusted the starting gold, meaning it should stop automatically adjusting to the difficulty setting default starting gold where applicable.
 
 		Timer m_StartGameButtonBlinkTimer; //!< Timer for blinking the start game button.
 

--- a/Source/Renderer/RenderTarget.cpp
+++ b/Source/Renderer/RenderTarget.cpp
@@ -16,7 +16,7 @@ RenderTarget::RenderTarget(const FloatRect& size, const FloatRect& defaultViewpo
 	m_Viewport = defaultViewport;
 	if (!defaultFB0) {
 		if (colorTexture.id != 0) {
-			m_Texture = colorTexture;
+			m_Texture = std::move(colorTexture);
 			m_ColorTextureOwned = false;
 		} else {
 			m_Texture = {

--- a/Source/Renderer/RenderTarget.h
+++ b/Source/Renderer/RenderTarget.h
@@ -30,9 +30,9 @@ namespace RTE {
 		/// @return The FBO.
 		GLuint GetFramebuffer() { return m_FBO; }
 		/// Getter for the color buffer
-		Texture2D GetColorTexture() { return m_Texture; }
+		const Texture2D& GetColorTexture() { return m_Texture; }
 		/// Getter for the depth buffer.
-		Texture2D GetDepthTexture() { return m_Depth; }
+		const Texture2D& GetDepthTexture() { return m_Depth; }
 
 		/// Getter for the size of this target.
 		const FloatRect& GetSize() { return m_Size; }

--- a/Source/System/InputMapping.h
+++ b/Source/System/InputMapping.h
@@ -29,7 +29,7 @@ namespace RTE {
 #pragma region Getters and Setters
 		/// Gets the description of the input scheme preset that this element is part of, if any preset has been set for this element's scheme.
 		/// @return The description associated with this element by the scheme preset, if any has been set. This string is empty otherwise.
-		std::string GetPresetDescription() const { return m_PresetDescription; }
+		const std::string& GetPresetDescription() const { return m_PresetDescription; }
 
 		/// Sets the description of the input scheme preset that this element is part of, if any preset has been set for this element's scheme.
 		/// @param presetDescription The description associated with this element by the scheme preset, if any has been set. This string should be empty otherwise.

--- a/Source/System/RTETools.cpp
+++ b/Source/System/RTETools.cpp
@@ -45,7 +45,7 @@ namespace RTE {
 		return startPos + (startToEnd * Lerp(scaleStart, scaleEnd, 0.0F, 1.0F, progressScalar));
 	}
 
-	Matrix Lerp(float scaleStart, float scaleEnd, Matrix startRot, Matrix endRot, float progressScalar) {
+	Matrix Lerp(float scaleStart, float scaleEnd, const Matrix& startRot, const Matrix& endRot, float progressScalar) {
 		const float fullTurn = c_PI * 2.0F;
 		float angleDelta = std::fmod(endRot.GetRadAngle() - startRot.GetRadAngle(), fullTurn);
 		float angleDistance = std::fmod(angleDelta * 2.0F, fullTurn) - angleDelta;

--- a/Source/System/RTETools.h
+++ b/Source/System/RTETools.h
@@ -143,7 +143,7 @@ namespace RTE {
 	/// @param endRot The end rotation of your Lerp.
 	/// @param progressScalar How far your Lerp has progressed. Automatically normalized through use of scaleStart and scaleEnd.
 	/// @return Interpolated value.
-	Matrix Lerp(float scaleStart, float scaleEnd, Matrix startRot, Matrix endRot, float progressScalar);
+	Matrix Lerp(float scaleStart, float scaleEnd, const Matrix& startRot, const Matrix& endRot, float progressScalar);
 
 	/// Nonlinear ease-in interpolation. Starts slow.
 	/// @param start Start value.

--- a/Source/System/Reader.h
+++ b/Source/System/Reader.h
@@ -65,7 +65,7 @@ namespace RTE {
 
 		/// Gets the path of the current file this reader is reading from.
 		/// @return A string with the path, relative from the working directory.
-		std::string GetCurrentFilePath() const { return m_FilePath; }
+		const std::string& GetCurrentFilePath() const { return m_FilePath; }
 
 		/// Gets the line of the current file line this reader is reading from.
 		/// @return A string with the line number that will be read from next.

--- a/Source/System/System.cpp
+++ b/Source/System/System.cpp
@@ -265,7 +265,7 @@ std::string System::ExtractZippedDataModule(const std::string& zippedModulePath)
 	std::array<char, s_FileBufferSize> fileBuffer;
 
 	// Go through and extract every file inside this zip, overwriting every colliding file that already exists in the install directory.
-	for (int i = 0; i < zippedModuleInfo.number_entry && !abortExtract; ++i) {
+	for (size_t i = 0; i < zippedModuleInfo.number_entry && !abortExtract; ++i) {
 		unz_file_info currentFileInfo;
 		std::array<char, s_MaxFileName> outputFileInfoData;
 		if (unzGetCurrentFileInfo(zippedModule, &currentFileInfo, outputFileInfoData.data(), s_MaxFileName, nullptr, 0, nullptr, 0) != UNZ_OK) {
@@ -348,10 +348,11 @@ std::string System::ExtractZippedDataModule(const std::string& zippedModulePath)
 				} while (bytesRead > 0 && outputFile);
 
 				fclose(outputFile);
-				unzCloseCurrentFile(zippedModule);
-
-				extractionProgressReport << "\tExtracted file: " + outputFileName + "\n";
 			}
+
+			unzCloseCurrentFile(zippedModule);
+
+			extractionProgressReport << "\tExtracted file: " + outputFileName + "\n";
 		}
 
 		if ((i + 1) < zippedModuleInfo.number_entry && unzGoToNextFile(zippedModule) != UNZ_OK) {

--- a/Source/System/System.cpp
+++ b/Source/System/System.cpp
@@ -323,35 +323,35 @@ std::string System::ExtractZippedDataModule(const std::string& zippedModulePath)
 			FILE* outputFile = fopen(outputFileName.c_str(), "wb");
 			if (outputFile == nullptr) {
 				extractionProgressReport << "\tSkipped file: " + outputFileName + " - Could not open/create destination file!\n";
+			} else {
+				// Write the entire file out, reading in buffer size chunks and spitting them out to the output stream.
+				bool abortWrite = false;
+				int bytesRead = 0;
+				int totalBytesRead = 0;
+				do {
+					bytesRead = unzReadCurrentFile(zippedModule, fileBuffer.data(), s_FileBufferSize);
+					totalBytesRead += bytesRead;
+
+					if (bytesRead < 0) {
+						extractionProgressReport << "\tSkipped file: " + outputFileName + " - File is empty or corrupt!\n";
+						abortWrite = true;
+						// Sanity check how damn big this file we're writing is becoming. could prevent zip bomb exploits: http://en.wikipedia.org/wiki/Zip_bomb
+					} else if (totalBytesRead >= s_MaxUnzippedFileSize) {
+						extractionProgressReport << "\tSkipped file: " + outputFileName + " - File is too large, extract it manually!\n";
+						abortWrite = true;
+					}
+					if (abortWrite) {
+						break;
+					}
+					fwrite(fileBuffer.data(), bytesRead, 1, outputFile);
+					// Keep going while bytes are still being read (0 means end of file).
+				} while (bytesRead > 0 && outputFile);
+
+				fclose(outputFile);
+				unzCloseCurrentFile(zippedModule);
+
+				extractionProgressReport << "\tExtracted file: " + outputFileName + "\n";
 			}
-
-			// Write the entire file out, reading in buffer size chunks and spitting them out to the output stream.
-			bool abortWrite = false;
-			int bytesRead = 0;
-			int totalBytesRead = 0;
-			do {
-				bytesRead = unzReadCurrentFile(zippedModule, fileBuffer.data(), s_FileBufferSize);
-				totalBytesRead += bytesRead;
-
-				if (bytesRead < 0) {
-					extractionProgressReport << "\tSkipped file: " + outputFileName + " - File is empty or corrupt!\n";
-					abortWrite = true;
-					// Sanity check how damn big this file we're writing is becoming. could prevent zip bomb exploits: http://en.wikipedia.org/wiki/Zip_bomb
-				} else if (totalBytesRead >= s_MaxUnzippedFileSize) {
-					extractionProgressReport << "\tSkipped file: " + outputFileName + " - File is too large, extract it manually!\n";
-					abortWrite = true;
-				}
-				if (abortWrite) {
-					break;
-				}
-				fwrite(fileBuffer.data(), bytesRead, 1, outputFile);
-				// Keep going while bytes are still being read (0 means end of file).
-			} while (bytesRead > 0 && outputFile);
-
-			fclose(outputFile);
-			unzCloseCurrentFile(zippedModule);
-
-			extractionProgressReport << "\tExtracted file: " + outputFileName + "\n";
 		}
 
 		if ((i + 1) < zippedModuleInfo.number_entry && unzGoToNextFile(zippedModule) != UNZ_OK) {

--- a/Source/System/Writer.h
+++ b/Source/System/Writer.h
@@ -40,15 +40,15 @@ namespace RTE {
 #pragma region Getters
 		/// Gets the path to the file being written.
 		/// @return The full path to the file being written.
-		std::string GetFilePath() const { return m_FilePath; }
+		const std::string& GetFilePath() const { return m_FilePath; }
 
 		/// Gets the name (without path) of the file being written.
 		/// @return The name of file being written.
-		std::string GetFileName() const { return m_FileName; }
+		const std::string& GetFileName() const { return m_FileName; }
 
 		/// Gets the folder path (without filename) to where the file is being written.
 		/// @return The name of folder being written in.
-		std::string GetFolderPath() const { return m_FolderPath; }
+		const std::string& GetFolderPath() const { return m_FolderPath; }
 #pragma endregion
 
 #pragma region Writing Operations


### PR DESCRIPTION
Ran `cppcheck` on the codebase and cleaned up most lints that it outputs.

The specific invocation I used:

```
cppcheck --project=compile_commands.json --file-filter=Source/* --check-level=exhaustive --enable=performance,information,missingInclude --suppress=missingIncludeSystem
```

(copy `compile_commands.json` from build dir to root of the project first of course)

Also includes some error handling fixups in AudioMan, some grammar fixes, and whatnot else Code Improvement™

bub fix 👍