### PR TITLE
Native*AI - Don't consider legless creatures as always in-flight

### DIFF
--- a/Data/Base.rte/AI/NativeCrabAI.lua
+++ b/Data/Base.rte/AI/NativeCrabAI.lua
@@ -321,14 +321,7 @@ function NativeCrabAI:Update(Owner)
 			end
 		end
 
-		local newFlying = false;
-		if not (Owner.LeftFGLeg and Owner.RightFGLeg and Owner.LeftBGLeg and Owner.RightBGLeg) then
-			newFlying = true;
-		end
-
-		if self.groundContact < 0 then
-			newFlying = true;
-		end
+		local newFlying = self.groundContact < 0;
 
 		if self.flying ~= newFlying then
 			Owner:SendMessage("AI_IsFlying", newFlying);

--- a/Data/Base.rte/AI/NativeHumanAI.lua
+++ b/Data/Base.rte/AI/NativeHumanAI.lua
@@ -260,14 +260,7 @@ function NativeHumanAI:Update(Owner)
 			end
 		end
 
-		local newFlying = false;
-		if not (Owner.FGLeg and Owner.BGLeg) then
-			newFlying = true;
-		end
-
-		if self.groundContact < 0 then
-			newFlying = true;
-		end
+		local newFlying = self.groundContact < 0;
 
 		if self.flying ~= newFlying then
 			Owner:SendMessage("AI_IsFlying", newFlying);


### PR DESCRIPTION
Flight status is already reasonably handled by self.groundContact logic.

This patch fixes their ability to actually complete pathfinding by normal criteria instead of only via getting close to the final point.

Video of before and after (At 0:18 I pressed F2 when opening the console to reload all scripts and apply the patch):

https://github.com/user-attachments/assets/b2d10b88-c144-404f-862d-dc89ae57bfd0

