### PR TITLE
Prevent Constructor from building out of bounds

### DIFF
--- a/Data/Base.rte/Devices/Tools/Constructor/Constructor.lua
+++ b/Data/Base.rte/Devices/Tools/Constructor/Constructor.lua
@@ -471,6 +471,8 @@ function Update(self)
 
 			if cursorMovement:MagnitudeIsGreaterThan(0) then
 				self.cursor = self.cursor + (mouseControlled and cursorMovement or cursorMovement:SetMagnitude(self.cursorMoveSpeed * (aiming and 0.5 or 1)));
+
+				SceneMan:ForceBounds(self.cursor);
 			end
 
 			local precise = not mouseControlled and aiming;
@@ -562,21 +564,23 @@ function Update(self)
 					for x = 1, cellSize do
 						for y = 1, cellSize do
 							local pos = Vector(startPos.X + x, startPos.Y + y);
-							local strengthRatio = SceneMan:GetMaterialFromID(SceneMan:GetTerrMatter(pos.X, pos.Y)).StructuralIntegrity/self.digStrength;
-							if strengthRatio < 1 and SceneMan:GetMOIDPixel(pos.X, pos.Y) == rte.NoMOID then
-								local name = "";
-								if bx + x == 0 or bx + x == self.buildList[1][4] - 1 or by + y == 0 or by + y == self.buildList[1][4] - 1 then
-									name = "Base.rte/Constructor Border Tile " .. math.random(4);
-								else
-									name = "Base.rte/Constructor Tile " .. math.random(16);
-								end
-								
-								local terrainObject = CreateTerrainObject(name);
-								terrainObject.Pos = pos;
-								SceneMan:AddSceneObject(terrainObject);
+							if SceneMan:IsWithinBounds(pos.X, pos.Y, 0) then
+								local strengthRatio = SceneMan:GetMaterialFromID(SceneMan:GetTerrMatter(pos.X, pos.Y)).StructuralIntegrity/self.digStrength;
+								if strengthRatio < 1 and SceneMan:GetMOIDPixel(pos.X, pos.Y) == rte.NoMOID then
+									local name = "";
+									if bx + x == 0 or bx + x == self.buildList[1][4] - 1 or by + y == 0 or by + y == self.buildList[1][4] - 1 then
+										name = "Base.rte/Constructor Border Tile " .. math.random(4);
+									else
+										name = "Base.rte/Constructor Tile " .. math.random(16);
+									end
 
-								didBuild = true;
-								totalCost = 1 - strengthRatio;
+									local terrainObject = CreateTerrainObject(name);
+									terrainObject.Pos = pos;
+									SceneMan:AddSceneObject(terrainObject);
+
+									didBuild = true;
+									totalCost = 1 - strengthRatio;
+								end
 							end
 						end
 					end


### PR DESCRIPTION
Without this patch, the user can aim and click out of scene bounds with the order construction cursor.

This is suboptimal because building there just wastes material, and it can get annoying and disorienting if the cursor ends up out of bounds.