### PR TITLE
Fix meson pch options

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -100,7 +100,7 @@ jobs:
           CC: "ccache gcc"
           CXX: "ccache g++"
         run: |
-          meson setup --buildtype=${{inputs.build_type}} -Ddebug_type=${{inputs.debug_level}} -Db_lto=false build
+          meson setup --buildtype=${{inputs.build_type}} -Ddebug_type=${{inputs.debug_level}} -Db_lto=false -Db_pch=false build
 
       - name: Configure for AppImage
         if: ${{inputs.upload_artefacts}}
@@ -201,7 +201,7 @@ jobs:
         env:
           LDFLAGS: "-static-libgcc -static-libstdc++"
         run: |
-          meson setup --cross-file=${{steps.osxcross.outputs.meson-osxcross}} --buildtype=${{inputs.build_type}} -Ddebug_type=${{inputs.debug_level}} -Db_lto=false build
+          meson setup --cross-file=${{steps.osxcross.outputs.meson-osxcross}} --buildtype=${{inputs.build_type}} -Ddebug_type=${{inputs.debug_level}} -Db_lto=false -Db_pch=false build
 
       - name: Configure for App Bundle
         if: ${{inputs.upload_artefacts}}
@@ -262,7 +262,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson setup --buildtype=${{inputs.build_type}} -Ddebug_type=${{inputs.debug_level}} --vsenv build
+          meson setup -Db_pch=false --buildtype=${{inputs.build_type}} -Ddebug_type=${{inputs.debug_level}} --vsenv build
 
       - name: Build
         run: |

--- a/Source/meson.build
+++ b/Source/meson.build
@@ -1,9 +1,4 @@
-
-if use_pch
-  pch = meson.current_source_dir()/'System/StandardIncludes.h'
-else
-  pch = ''
-endif
+pch = meson.current_source_dir()/'System/StandardIncludes.h'
 sources = []
 source_libs = []
 source_inc_dirs += [include_directories(

--- a/meson.build
+++ b/meson.build
@@ -26,19 +26,6 @@ if get_option('debug') and get_option('b_lto')
   warning('Link time optimization enabled in debug mode, debug symbols may not be fully available. Disable b_lto with "meson configure -Db_lto=false".')
 endif
 
-use_pch = get_option('use_pch').enabled()
-
-if get_option('use_pch').auto()
-  ccache = find_program('ccache', required : false)
-  if ccache.found()
-    message('Detected ccache, disabling precompiled headers')
-    use_pch = false
-  else
-    message('Using precompiled headers')
-    use_pch = true
-  endif
-endif
-
 if compiler.get_argument_syntax()== 'gcc' # used for gcc compatible compilers
   # Build against system libraries on linux
   message('gcc detected')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,5 +16,3 @@ option('tracy_enable', type: 'boolean', value: true, description: 'Enable Tracy 
 option('tracy_callstack', type : 'integer', value : 0, description : 'Enfore callstack collection for tracy regions')
 option('tracy_on_demand', type : 'boolean', value : true, description : 'On-demand profiling')
 option('tracy_debuginfod', type : 'boolean', value : false, description : 'Enable debuginfod support')
-
-option('use_pch', type : 'feature', value : 'auto')


### PR DESCRIPTION
Removes broken `use_pch` option, which already existed as a meson builtin option `b_pch` (Needs to be explicitly specified now, was mostly only relevant in CI anyways)