### PR TITLE
Improve LimbPath.cpp - rewrite ReportProgress, etc

### DIFF
--- a/Source/Entities/LimbPath.cpp
+++ b/Source/Entities/LimbPath.cpp
@@ -337,9 +337,9 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 		// This rest of the code will be working in local space, so convert input limb pos to that.
 		Vector limbPosLocal = ToLocalSpace(limbPos);
 
-		//
+
 		// Iterate over all segments and find one whose target is closest to the limb position.
-		//
+
 
 		// Segment positions are accumulative, so keep an accumulator.
 		Vector currentSegmentStartPos = GetCurrentSegStartLocal(); // Will be needed later.
@@ -350,12 +350,27 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 		std::deque<Vector>::iterator closestSegment = m_CurrentSegment;
 
 		for (std::deque<Vector>::iterator itr = m_CurrentSegment; itr != m_Segments.end(); ++itr) {
-			if (itr != m_CurrentSegment) {
+
+			// We want to find a closest segment to work off of, but we don't want to
+			// snap from collision-enabled segments to collision-disabled segments,
+			// because doing so tends to produce erratic foot behavior.
+
+			// If the current segment of the limbpath is collision-enabled...
+			if (!FootCollisionsShouldBeDisabled()) {
+				// If the currently looked at segment is collision-disabled...
 				if (m_FootCollisionsDisabledSegment >= 0 &&
 						m_Segments.size() - (itr - m_Segments.begin()) <= m_FootCollisionsDisabledSegment) {
-					// We've already picked a segment (at least the current one),
-					// and the remaining ones are ones with collisions disabled.
-					// Ignore these.
+
+					// ...Then break.
+
+					// Note: if the first of the above two checks has passed,
+					// this means that the current segment is collision-enabled.
+					// And, since this iterator starts with it, this means that
+					// *at least* the current segment was picked as closest already.
+					//
+					// In other words, if this break was hit, then closest segment vars have
+					// been properly initialized already. Therefore, it's safe to break.
+
 					break;
 				}
 			}
@@ -369,16 +384,13 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 				closestSegmentStartPos = thisSegmentStartPos;
 				closestSegmentTargetDistanceSqr = thisSegmentDistanceSqr;
 				closestSegment = itr;
-			} else {
-				// This one is *farther* than the last one.
-				// Assuming next segments will be only farther and farther, just break now.
-				break;
 			}
 		}
 
-		// We will want to compute progress to whatever the new segment is.
-		float distanceToCurrentSegmentTargetSqr;
 
+		// Branches below will determine the new current segment and write the distance to it here.
+		// We need this distance to compute progress towards it, whatever it ends up being.
+		float distanceToCurrentSegmentTargetSqr;
 
 		if (closestSegmentTargetDistanceSqr < m_SegmentEndedThreshold * m_SegmentEndedThreshold) {
 			// We're sufficiently close to this segment's target to go on.

--- a/Source/Entities/LimbPath.cpp
+++ b/Source/Entities/LimbPath.cpp
@@ -172,6 +172,23 @@ Vector LimbPath::RotatePoint(const Vector& point) const {
 	return (((point - offset) * m_Rotation) + offset) + m_PositionOffset;
 }
 
+Vector LimbPath::InverseRotatePoint(const Vector& point) const {
+	Vector offset = (m_RotationOffset).GetXFlipped(m_HFlipped);
+	return (((point - m_PositionOffset) - offset) / m_Rotation) + offset;
+}
+
+Vector LimbPath::ToLocalSpace(const Vector& position) const {
+	// The position might be on one side of a border of a wrapping scene while the joint is on another.
+	// Account for that.
+	Vector posWrapped = m_JointPos + g_SceneMan.ShortestDistance(m_JointPos, position);
+
+	return InverseRotatePoint(posWrapped - m_JointPos) / GetTotalScaleMultiplier();
+}
+
+Vector LimbPath::ToWorldSpace(const Vector& position) const {
+	return m_JointPos + (RotatePoint(position * GetTotalScaleMultiplier()));
+}
+
 int LimbPath::Save(Writer& writer) const {
 	Entity::Save(writer);
 
@@ -199,43 +216,44 @@ void LimbPath::Destroy(bool notInherited) {
 	Clear();
 }
 
-Vector LimbPath::GetProgressPos() {
+Vector LimbPath::GetCurrentSegStartLocal() const {
 	Vector returnVec(m_Start);
-	if (IsStaticPoint()) {
-		return m_JointPos + (RotatePoint(returnVec * GetTotalScaleMultiplier()));
+
+	if (!IsStaticPoint()) {
+		// Add all the segments before the current one
+		std::deque<Vector>::const_iterator itr;
+		for (itr = m_Segments.begin(); itr != m_CurrentSegment; ++itr) {
+			returnVec += *itr;
+		}
 	}
 
-	// Add all the segments before the current one
-	std::deque<Vector>::const_iterator itr;
-	for (itr = m_Segments.begin(); itr != m_CurrentSegment; ++itr) {
-		returnVec += *itr;
+	return returnVec;
+}
+
+Vector LimbPath::GetProgressPos() {
+	Vector returnVec = GetCurrentSegStartLocal();
+
+	if (!IsStaticPoint()) {
+		if (m_CurrentSegment != m_Segments.end()) {
+			// Add approximation based on progress.
+			returnVec += *m_CurrentSegment * m_SegProgress;
+		}
 	}
 
-	// Add any from the progress made on the current one
-	if (itr != m_Segments.end()) {
-		returnVec += *m_CurrentSegment * m_SegProgress;
-	}
-
-	return m_JointPos + (RotatePoint(returnVec * GetTotalScaleMultiplier()));
+	return ToWorldSpace(returnVec);
 }
 
 Vector LimbPath::GetCurrentSegTarget() {
-	Vector returnVec(m_Start);
-	if (IsStaticPoint()) {
-		return m_JointPos + (RotatePoint(returnVec * GetTotalScaleMultiplier()));
+	Vector returnVec = GetCurrentSegStartLocal();
+
+	if (!IsStaticPoint()) {
+		if (m_CurrentSegment != m_Segments.end()) {
+			// Add the current one as well.
+			returnVec += *m_CurrentSegment;
+		}
 	}
 
-	std::deque<Vector>::const_iterator itr;
-
-	for (itr = m_Segments.begin(); itr != m_CurrentSegment; ++itr) {
-		returnVec += *itr;
-	}
-
-	if (itr != m_Segments.end()) {
-		returnVec += *m_CurrentSegment;
-	}
-
-	return m_JointPos + (RotatePoint(returnVec * GetTotalScaleMultiplier()));
+	return ToWorldSpace(returnVec);
 }
 
 Vector LimbPath::GetCurrentVel(const Vector& limbPos) {
@@ -292,29 +310,119 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 	if (IsStaticPoint()) {
 		const float staticPointEndedThreshold = 1.0F;
 		m_Ended = g_SceneMan.ShortestDistance(limbPos, GetCurrentSegTarget()).MagnitudeIsLessThan(staticPointEndedThreshold);
-	} else {
-		// Check if we are sufficiently close to the target to start going after the next one.
+	} else if (m_CurrentSegment == m_Segments.end()) {
+		// Current path has already come to an end. Compute progress and m_Ended based on last segment's target.
 		Vector distVec = g_SceneMan.ShortestDistance(limbPos, GetCurrentSegTarget());
 		float distance = distVec.GetMagnitude();
 		float segMag = (*m_CurrentSegment * GetTotalScaleMultiplier()).GetMagnitude();
 
-		if (distance < m_SegmentEndedThreshold) {
-			if (++(m_CurrentSegment) == m_Segments.end()) {
-				--(m_CurrentSegment);
-				// Get normalized progress measure toward the target.
-				m_SegProgress = distance > segMag ? 0.0F : (1.0F - (distance / segMag));
-				m_Ended = true;
+		// Get normalized progress measure toward the target.
+		m_SegProgress = distance > segMag ? 0.0F : (1.0F - (distance / segMag));
+
+		m_Ended = distVec.MagnitudeIsLessThan(m_SegmentEndedThreshold);
+	} else {
+		// Presume we're not done with all path segments until proven otherwise.
+		m_Ended = false;
+
+		// Check if we are sufficiently close to the current target, or any of the next ones,
+		// to start going to whatever target is after that one.
+		//
+		// The limb might have been yanked and is closer to one of the future targets, so check them too.
+
+		// This rest of the code will be working in local space, so convert input limb pos to that.
+		Vector limbPosLocal = ToLocalSpace(limbPos);
+
+		//
+		// Iterate over all segments and find one whose target is closest to the limb position.
+		//
+
+		// Segment positions are accumulative, so keep an accumulator.
+		Vector currentSegmentStartPos = GetCurrentSegStartLocal(); // Will be needed later.
+		Vector segmentPosAccumulator = currentSegmentStartPos;
+
+		Vector closestSegmentStartPos;
+		float closestSegmentTargetDistanceSqr = std::numeric_limits<float>::max();
+		std::deque<Vector>::iterator closestSegment = m_CurrentSegment;
+
+		for (std::deque<Vector>::iterator itr = m_CurrentSegment; itr != m_Segments.end(); ++itr) {
+			if (itr != m_CurrentSegment) {
+				if (m_FootCollisionsDisabledSegment >= 0 && GetSegCount() - (itr - m_Segments.begin()) <= m_FootCollisionsDisabledSegment) {
+					// We've already picked a segment, and the remaining ones are ones with collisions disabled.
+					// Ignore these.
+					break;
+				}
 			}
-			// Next segment!
-			else {
-				m_SegProgress = 0.0F;
+
+			Vector thisSegmentStartPos = segmentPosAccumulator;
+			segmentPosAccumulator += *itr; // The accumulator's value is now the target pos of this segment.
+			float thisSegmentDistanceSqr = (segmentPosAccumulator - limbPosLocal).GetSqrMagnitude();
+
+			if (thisSegmentDistanceSqr < closestSegmentTargetDistanceSqr) {
+				// This one's closer.
+				closestSegmentStartPos = thisSegmentStartPos;
+				closestSegmentTargetDistanceSqr = thisSegmentDistanceSqr;
+				closestSegment = itr;
+			} else {
+				// This one is *farther* than the last one.
+				// Assuming next segments will be only farther and farther, just break now.
+				break;
+			}
+		}
+
+		// We will want to compute progress to whatever the new segment is.
+		float distanceToCurrentSegmentTarget;
+
+
+		if (closestSegmentTargetDistanceSqr < m_SegmentEndedThreshold * m_SegmentEndedThreshold) {
+			// We're sufficiently close to this segment's target to go on.
+			// Either declare this path ended, or continue from the next segment.
+
+			if (closestSegment + 1 == m_Segments.end()) {
+				// Closest segment is the last segment and we are at its target. Declare done.
+				m_Ended = true;
+				m_CurrentSegment = closestSegment;
+
+				distanceToCurrentSegmentTarget = std::sqrt(closestSegmentTargetDistanceSqr);
+
+			} else {
+				// Time to switch to next segment!
 				m_SegTimer.Reset();
-				m_Ended = false;
+
+				m_CurrentSegment = closestSegment + 1;
+
+				Vector currentSegmentTarget = closestSegmentStartPos + *closestSegment + *m_CurrentSegment;
+				distanceToCurrentSegmentTarget = (currentSegmentTarget - limbPosLocal).GetMagnitude();
 			}
 		} else {
-			m_SegProgress = distance > segMag ? 0.0F : (1.0F - (distance / segMag));
-			m_Ended = false;
+			// We're not close enough to that closest segment's target, but we can still try to do better.
+
+			Vector currentSegmentTargetPos = currentSegmentStartPos + *m_CurrentSegment;
+			float currentSegmentDistanceSqr = (currentSegmentTargetPos - limbPosLocal).GetSqrMagnitude();
+
+			if (closestSegmentTargetDistanceSqr < currentSegmentDistanceSqr) {
+				// The target for this closest segment is closer than the current segment's.
+				// Fast-forward to it.
+				m_SegTimer.Reset();
+
+				m_CurrentSegment = closestSegment;
+
+				distanceToCurrentSegmentTarget = std::sqrt(closestSegmentTargetDistanceSqr);
+			} else {
+				// Just get the distance to current segment's target.
+				Vector currentSegmentTarget = currentSegmentStartPos + *m_CurrentSegment;
+				distanceToCurrentSegmentTarget = (currentSegmentTarget - limbPosLocal).GetMagnitude();
+			}
 		}
+
+		// Now compute a normalized progress measure towards the current segment.
+
+		float currentSegmentMagnitude = m_CurrentSegment->GetMagnitude();
+
+		if (distanceToCurrentSegmentTarget > currentSegmentMagnitude)
+			// We're too far away from this target.
+			m_SegProgress = 0.0;
+		else
+			m_SegProgress = (1.0F - (distanceToCurrentSegmentTarget / currentSegmentMagnitude));
 	}
 }
 
@@ -343,13 +451,11 @@ float LimbPath::GetRegularProgress() const {
 }
 
 int LimbPath::GetCurrentSegmentNumber() const {
-	int progress = 0;
-	if (!m_Ended && !IsStaticPoint()) {
-		for (std::deque<Vector>::const_iterator itr = m_Segments.begin(); itr != m_CurrentSegment; ++itr) {
-			progress++;
-		}
+	if (m_Ended || IsStaticPoint()) {
+		return 0;
+	} else {
+		return m_CurrentSegment - m_Segments.begin();
 	}
-	return progress;
 }
 
 void LimbPath::Terminate() {
@@ -379,7 +485,7 @@ bool LimbPath::RestartFree(Vector& limbPos, MOID MOIDToIgnore, int ignoreTeam) {
 
 	if (IsStaticPoint()) {
 		Vector notUsed;
-		Vector targetPos = m_JointPos + (RotatePoint(m_Start * GetTotalScaleMultiplier()));
+		Vector targetPos = ToWorldSpace(m_Start);
 		Vector beginPos = targetPos;
 		// TODO: don't hardcode the beginpos
 		beginPos.m_Y -= 24;
@@ -517,8 +623,8 @@ void LimbPath::Draw(BITMAP* pTargetBitmap,
 	for (std::deque<Vector>::const_iterator itr = m_Segments.begin(); itr != m_Segments.end(); ++itr) {
 		nextPoint += *itr;
 
-		Vector prevWorldPosition = m_JointPos + (RotatePoint(prevPoint * GetTotalScaleMultiplier()) - targetPos);
-		Vector nextWorldPosition = m_JointPos + (RotatePoint(nextPoint * GetTotalScaleMultiplier()) - targetPos);
+		Vector prevWorldPosition = ToWorldSpace(prevPoint) - targetPos;
+		Vector nextWorldPosition = ToWorldSpace(nextPoint) - targetPos;
 		line(pTargetBitmap, prevWorldPosition.m_X, prevWorldPosition.m_Y, nextWorldPosition.m_X, nextWorldPosition.m_Y, color);
 
 		Vector min(std::min(prevWorldPosition.m_X, nextWorldPosition.m_X), std::min(prevWorldPosition.m_Y, nextWorldPosition.m_Y));

--- a/Source/Entities/LimbPath.cpp
+++ b/Source/Entities/LimbPath.cpp
@@ -313,11 +313,16 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 	} else if (m_CurrentSegment == m_Segments.end()) {
 		// Current path has already come to an end. Compute progress and m_Ended based on last segment's target.
 		Vector distVec = g_SceneMan.ShortestDistance(limbPos, GetCurrentSegTarget());
-		float distance = distVec.GetMagnitude();
-		float segMag = (*m_CurrentSegment * GetTotalScaleMultiplier()).GetMagnitude();
+		float distanceSqr = distVec.GetSqrMagnitude();
+		float segMagSqr = (*m_CurrentSegment * GetTotalScaleMultiplier()).GetSqrMagnitude();
 
 		// Get normalized progress measure toward the target.
-		m_SegProgress = distance > segMag ? 0.0F : (1.0F - (distance / segMag));
+
+		if (distanceSqr > segMagSqr)
+			// We're too far away from this target.
+			m_SegProgress = 0.0;
+		else
+			m_SegProgress = (1.0F - (std::sqrt(distanceSqr) / std::sqrt(segMagSqr)));
 
 		m_Ended = distVec.MagnitudeIsLessThan(m_SegmentEndedThreshold);
 	} else {
@@ -346,8 +351,10 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 
 		for (std::deque<Vector>::iterator itr = m_CurrentSegment; itr != m_Segments.end(); ++itr) {
 			if (itr != m_CurrentSegment) {
-				if (m_FootCollisionsDisabledSegment >= 0 && GetSegCount() - (itr - m_Segments.begin()) <= m_FootCollisionsDisabledSegment) {
-					// We've already picked a segment, and the remaining ones are ones with collisions disabled.
+				if (m_FootCollisionsDisabledSegment >= 0 &&
+						m_Segments.size() - (itr - m_Segments.begin()) <= m_FootCollisionsDisabledSegment) {
+					// We've already picked a segment (at least the current one),
+					// and the remaining ones are ones with collisions disabled.
 					// Ignore these.
 					break;
 				}
@@ -370,7 +377,7 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 		}
 
 		// We will want to compute progress to whatever the new segment is.
-		float distanceToCurrentSegmentTarget;
+		float distanceToCurrentSegmentTargetSqr;
 
 
 		if (closestSegmentTargetDistanceSqr < m_SegmentEndedThreshold * m_SegmentEndedThreshold) {
@@ -382,7 +389,7 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 				m_Ended = true;
 				m_CurrentSegment = closestSegment;
 
-				distanceToCurrentSegmentTarget = std::sqrt(closestSegmentTargetDistanceSqr);
+				distanceToCurrentSegmentTargetSqr = closestSegmentTargetDistanceSqr;
 
 			} else {
 				// Time to switch to next segment!
@@ -391,7 +398,7 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 				m_CurrentSegment = closestSegment + 1;
 
 				Vector currentSegmentTarget = closestSegmentStartPos + *closestSegment + *m_CurrentSegment;
-				distanceToCurrentSegmentTarget = (currentSegmentTarget - limbPosLocal).GetMagnitude();
+				distanceToCurrentSegmentTargetSqr = (currentSegmentTarget - limbPosLocal).GetSqrMagnitude();
 			}
 		} else {
 			// We're not close enough to that closest segment's target, but we can still try to do better.
@@ -406,23 +413,23 @@ void LimbPath::ReportProgress(const Vector& limbPos) {
 
 				m_CurrentSegment = closestSegment;
 
-				distanceToCurrentSegmentTarget = std::sqrt(closestSegmentTargetDistanceSqr);
+				distanceToCurrentSegmentTargetSqr = closestSegmentTargetDistanceSqr;
 			} else {
 				// Just get the distance to current segment's target.
 				Vector currentSegmentTarget = currentSegmentStartPos + *m_CurrentSegment;
-				distanceToCurrentSegmentTarget = (currentSegmentTarget - limbPosLocal).GetMagnitude();
+				distanceToCurrentSegmentTargetSqr = (currentSegmentTarget - limbPosLocal).GetSqrMagnitude();
 			}
 		}
 
 		// Now compute a normalized progress measure towards the current segment.
 
-		float currentSegmentMagnitude = m_CurrentSegment->GetMagnitude();
+		float currentSegmentMagnitudeSqr = m_CurrentSegment->GetSqrMagnitude();
 
-		if (distanceToCurrentSegmentTarget > currentSegmentMagnitude)
+		if (distanceToCurrentSegmentTargetSqr > currentSegmentMagnitudeSqr)
 			// We're too far away from this target.
 			m_SegProgress = 0.0;
 		else
-			m_SegProgress = (1.0F - (distanceToCurrentSegmentTarget / currentSegmentMagnitude));
+			m_SegProgress = (1.0F - (std::sqrt(distanceToCurrentSegmentTargetSqr) / std::sqrt(currentSegmentMagnitudeSqr)));
 	}
 }
 

--- a/Source/Entities/LimbPath.h
+++ b/Source/Entities/LimbPath.h
@@ -109,7 +109,7 @@ namespace RTE {
 
 		/// Gets the APPROXIMATE scene position that the limb was reported to be
 		/// last frame. This really shouldn't be used by external clients.
-		/// @return A Vector with the APPROXIAMTE scene/world coordinates of the limb as
+		/// @return A Vector with the APPROXIMATE scene/world coordinates of the limb as
 		/// reported last.
 		Vector GetProgressPos();
 
@@ -383,7 +383,9 @@ namespace RTE {
 		// The iterator to the segment of the path that the limb ended up on the end of
 		std::deque<Vector>::iterator m_CurrentSegment;
 
-		int m_FootCollisionsDisabledSegment; //!< The segment after which foot collisions will be disabled for this limbpath, if it's for legs.
+		// Count of segments at the end of the segments list for which foot collisions should be disabled
+		// for this limbpath, if it's for legs.
+		int m_FootCollisionsDisabledSegment;
 
 		// Normalized measure of how far the limb has progressed toward the
 		// current segment's target. 0.0 means its farther away than the
@@ -449,6 +451,26 @@ namespace RTE {
 		/// @param point The point to rotate.
 		/// @return The rotated point.
 		Vector RotatePoint(const Vector& point) const;
+
+		/// Inverse of RotatePoint.
+		/// @param point The rotated point
+		/// @return The point pre-rotation.
+		Vector InverseRotatePoint(const Vector& point) const;
+
+		/// Converts an input position, absolute and in scene/world space, to local space for this LimbPath,
+		/// taking into account rotation and scaling.
+		/// @param position World space position
+		/// @returns Local space position
+		Vector ToLocalSpace(const Vector& position) const;
+
+		/// Converts an input position, in local space for this LimbPath, into scene/world space,
+		/// taking into account rotation and scaling.
+		/// @param position Local space position
+		/// @returns World space position
+		Vector ToWorldSpace(const Vector& position) const;
+
+		// Gets the current segment's starting position (i.e. last segment's target) in local space.
+		Vector GetCurrentSegStartLocal() const;
 	};
 
 } // namespace RTE

--- a/Source/Entities/LimbPath.h
+++ b/Source/Entities/LimbPath.h
@@ -20,7 +20,7 @@ namespace RTE {
 
 		/// Public member variable, method and friend function declarations
 	public:
-		// Concrete allocation and cloning definitions
+		/// Concrete allocation and cloning definitions
 		EntityAllocation(LimbPath);
 		SerializableOverrideMethods;
 		ClassInfoGetters;
@@ -83,7 +83,7 @@ namespace RTE {
 
 		/// Gets the number of Vector:s the internal array of 'waypoints' or
 		/// segments of this LimbPath.
-		/// @return An int with he count.
+		/// @return An int with the count.
 		int GetSegCount() const { return m_Segments.size(); }
 
 		/// Gets a pointer to the segment at the given index. Ownership is NOT transferred.
@@ -369,77 +369,62 @@ namespace RTE {
 	protected:
 		static Entity::ClassInfo m_sClass;
 
-		// The starting point of the path.
-		Vector m_Start;
+		Vector m_Start; //!< The starting point of the path.
 
-		// The number of starting segments, counting into the path from its beginning,
-		// that upon restart of this path will be tried in reverse order till one which
-		// yields a starting position that is clear of terrain is found.
+		/// The number of starting segments, counting into the path from its beginning,
+		/// that upon restart of this path will be tried in reverse order till one which
+		/// yields a starting position that is clear of terrain is found.
 		size_t m_StartSegCount;
 
-		// Array containing the actual 'waypoints' or segments for the path.
-		std::deque<Vector> m_Segments;
+		std::deque<Vector> m_Segments; //!< Array containing the actual 'waypoints' or segments for the path.
 
-		// The iterator to the segment of the path that the limb ended up on the end of
+		/// The iterator to the segment of the path that the limb ended up on the end of.
 		std::deque<Vector>::iterator m_CurrentSegment;
 
-		// Count of segments at the end of the segments list for which foot collisions should be disabled
-		// for this limbpath, if it's for legs.
+		/// Count of segments at the end of the segments list for which foot collisions should be disabled
+		/// for this limbpath, if it's for legs.
 		int m_FootCollisionsDisabledSegment;
 
-		// Normalized measure of how far the limb has progressed toward the
-		// current segment's target. 0.0 means its farther away than the
-		// magnitude of the entire segment. 0.5 means it's half the mag of the segment
-		// away from the target.
+		/// Normalized measure of how far the limb has progressed toward the current
+		/// segment's target.
+		///
+		/// 0.0 means its farther away than the magnitude of the entire segment.
+		/// 0.5 means it's half the mag of the segment away from the target.
 		float m_SegProgress;
 
-		// The constant speed that the limb traveling this path has in m/s.
-		float m_TravelSpeed;
+		float m_TravelSpeed; //!< The constant speed that the limb traveling this path has in m/s.
 
-		// How close we must get to the end of each segment to consider it finished
-		float m_SegmentEndedThreshold;
+		float m_SegmentEndedThreshold; //!< How close we must get to the end of each segment to consider it finished
 
-		// The base/current travel speed multiplier
-		float m_BaseTravelSpeedMultiplier;
-		float m_CurrentTravelSpeedMultiplier;
+		float m_BaseTravelSpeedMultiplier; //!< The base travel speed multiplier
+		float m_CurrentTravelSpeedMultiplier; //!< The current travel speed multiplier
 
-		// The base/current scale multiplier (we extend the walkpath when running fast to take longer strides)
-		// This is a vector to allow scaling on seperate axis
+		/// The base scale multiplier for both axes.
 		Vector m_BaseScaleMultiplier;
+		/// The current scale multiplier for both axes. (we extend the walkpath when running fast to take longer strides)
 		Vector m_CurrentScaleMultiplier;
 
-		// The max force that a limb travelling along this path can push.
-		// In kg * m/(s^2)
-		float m_PushForce;
+		float m_PushForce; //!< The max force that a limb travelling along this path can push, in kg * m/(s^2).
 
-		// The latest known position of the owning actor's joint in world coordinates.
-		Vector m_JointPos;
-		// The latest known velocity of the owning actor's joint in world coordinates.
-		Vector m_JointVel;
-		// The rotation applied to this walkpath.
-		Matrix m_Rotation;
-		// The point we should be rotated around, in local space.
-		Vector m_RotationOffset;
-		// The offset to apply to our walkpath position, in local space.
-		Vector m_PositionOffset;
+		Vector m_JointPos; //!< The latest known position of the owning actor's joint in world coordinates.
+		Vector m_JointVel; //!< The latest known velocity of the owning actor's joint in world coordinates.
+		Matrix m_Rotation; //!< The rotation applied to this walkpath.
+		Vector m_RotationOffset; //!< The point we should be rotated around, in local space.
+		Vector m_PositionOffset; //!< The offset to apply to our walkpath position, in local space.
 
-		// If GetNextTimeSeg() couldn't use up all frame time because the current segment
-		// ended,this var stores the remainder of time that should be used to progress
-		// on the next segment during the same frame.
+		/// If GetNextTimeSeg() couldn't use up all frame time because the current segment
+		/// ended, this var stores the remainder of time that should be used to progress
+		/// on the next segment during the same frame.
 		float m_TimeLeft;
 
-		// Times the amount of sim time spent since the last path traversal was started
-		Timer m_PathTimer;
-		// Times the amount of sim time spent pursuing the current segment's target.
-		Timer m_SegTimer;
+		Timer m_PathTimer; //!< Records the amount of sim time spent since the last path traversal was started.
+		Timer m_SegTimer; //!< Records the amount of sim time spent pursuing the current segment's target.
 
-		// Total length of this LimbPath, including the alternative starting segments, in pixel units
-		float m_TotalLength;
-		// Length of this LimbPath, excluding the alternative starting segments.
-		float m_RegularLength;
-		bool m_SegmentDone;
-		bool m_Ended;
-		bool m_HFlipped;
+		float m_TotalLength; //!< Total length of this LimbPath, including the alternative starting segments, in pixel units
+		float m_RegularLength; //!< Length of this LimbPath, excluding the alternative starting segments.
+		bool m_SegmentDone; //!< Unused?
+		bool m_Ended; //!< True if this path has ended. See method `PathEnded` for more information.
+		bool m_HFlipped; //!< True if this path is horizontally flipped.
 
 		/// Private member variable and method declarations
 	private:
@@ -469,7 +454,7 @@ namespace RTE {
 		/// @returns World space position
 		Vector ToWorldSpace(const Vector& position) const;
 
-		// Gets the current segment's starting position (i.e. last segment's target) in local space.
+		/// Gets the current segment's starting position (i.e. last segment's target) in local space.
 		Vector GetCurrentSegStartLocal() const;
 	};
 

--- a/Source/System/Matrix.cpp
+++ b/Source/System/Matrix.cpp
@@ -136,12 +136,13 @@ Vector Matrix::operator/(const Vector& rhs) {
 	}
 
 	Vector retVec = rhs;
-	// Apply flipping as set.
-	retVec.m_X = m_Flipped[X] ? -retVec.m_X : retVec.m_X;
-	retVec.m_Y = m_Flipped[Y] ? -retVec.m_Y : retVec.m_Y;
 
 	// Do the matrix multiplication.
 	retVec.SetXY(m_Elements[0][0] * retVec.m_X + m_Elements[1][0] * retVec.m_Y, m_Elements[0][1] * retVec.m_X + m_Elements[1][1] * retVec.m_Y);
+
+	// Apply flipping as set.
+	retVec.m_X = m_Flipped[X] ? -retVec.m_X : retVec.m_X;
+	retVec.m_Y = m_Flipped[Y] ? -retVec.m_Y : retVec.m_Y;
 
 	return retVec;
 }

--- a/Source/System/Matrix.h
+++ b/Source/System/Matrix.h
@@ -233,6 +233,15 @@ namespace RTE {
 		/// @param rhs A Matrix reference as the right hand side operand.
 		/// @return A reference to the resulting Vector.
 		friend Vector operator*(const Vector& lhs, const Matrix& rhs) {
+			// Multiplication might call Matrix::UpdateElements and therefore
+			// needs to modify it.
+			//
+			// However, this function signature uses const ref for the matrix.
+			//
+			// Therefore, the only way to perform this as needed
+			// without changing it to mut ref is by copying the matrix.
+			//
+			// TODO: see if we can unjank this?
 			Matrix m(rhs);
 			return m * lhs;
 		}
@@ -248,6 +257,15 @@ namespace RTE {
 		/// @param rhs A Matrix reference as the right hand side operand.
 		/// @return A reference to the resulting Vector.
 		friend Vector operator/(const Vector& lhs, const Matrix& rhs) {
+			// Division might call Matrix::UpdateElements and therefore
+			// needs to modify it.
+			//
+			// However, this function signature uses const ref for the matrix.
+			//
+			// Therefore, the only way to perform this as needed
+			// without changing it to mut ref is by copying the matrix.
+			//
+			// TODO: see if we can unjank this?
 			Matrix m(rhs);
 			return m / lhs;
 		}

--- a/Source/System/Matrix.h
+++ b/Source/System/Matrix.h
@@ -238,6 +238,7 @@ namespace RTE {
 		}
 
 		/// Division operator overload for a Matrix and a Vector. The vector will be transformed according to the Matrix's elements.
+		/// Flipping, if set, is performed after rotating.
 		/// @param rhs A Vector reference as the right hand side operand.
 		/// @return The resulting transformed Vector.
 		Vector operator/(const Vector& rhs);
@@ -246,7 +247,10 @@ namespace RTE {
 		/// @param lhs A Vector reference as the left hand side operand.
 		/// @param rhs A Matrix reference as the right hand side operand.
 		/// @return A reference to the resulting Vector.
-		friend Vector operator/(const Vector& lhs, Matrix& rhs) { return rhs / lhs; }
+		friend Vector operator/(const Vector& lhs, const Matrix& rhs) {
+			Matrix m(rhs);
+			return m / lhs;
+		}
 
 		/// Self-multiplication operator overload for Vector with a Matrix.
 		/// @param lhs A Vector reference as the left hand side operand.


### PR DESCRIPTION
The rewrite checks all path segments from the current one to the last and finds the best one to continue from, instead of fixating on just the one. This helps in cases where feet might be yanked along the path by excessive horizontal acceleration, or when the player switches look direction while moving. Removes random stumbling too, mostly.

This doesn't perfectly fix everything ever, but it definitely makes it better I think. It's now more feasible to spam the jetpack and literally drag feet on the ground when the character's baggage is too heavy lol

Also fix Vector/Matrix division, making it the proper inverse of multiplication and applicable to a const Matrix. Figuring out why the math did not math definitely made me pull a hair or two lmao

Played a round of Bunker Breach with this patch and everything appears fine. Going over the scene wrap border break anything either.

---

Old behavior:

https://github.com/user-attachments/assets/c75b9f5c-fba3-4879-a5e7-80b7307e9b27

New behavior:

https://github.com/user-attachments/assets/a6cd142e-0fd4-4983-9e53-41c6df89ed99


