### PR TITLE
Fix wrong initialization of capture progress for neutral GenericCapturables

### DIFF
--- a/Data/Base.rte/Scenes/Objects/Bunkers/BunkerSystems/GenericCapturable/GenericCapturable.lua
+++ b/Data/Base.rte/Scenes/Objects/Bunkers/BunkerSystems/GenericCapturable/GenericCapturable.lua
@@ -46,7 +46,18 @@ function Create(self)
 		end
 	end
 	
-	self.captureProgress = self:NumberValueExists("captureProgress") and self:GetNumberValue("captureProgress") or 1;
+	-- If we have a saved value, use that.
+	if self:NumberValueExists("captureProgress") then
+		self.captureProgress = self:GetNumberValue("captureProgress")
+	else
+		-- Otherwise, initialize properly according to whether we are captured by a real team or not by default.
+		if self.Team == -1 then
+			self.captureProgress = 0.0;
+		else
+			self.captureProgress = 1.0;
+		end
+	end
+	
 	self.capturingTeam = self:NumberValueExists("capturingTeam") and self:GetNumberValue("capturingTeam") or self.Team;
 	self.dominantTeam = self:NumberValueExists("dominantTeam") and self:GetNumberValue("dominantTeam") or self.Team;
 	


### PR DESCRIPTION
StartTeam -1 capturables initialized to 1.0 captureProgress even though they're supposed to be at 0.0 if not captured by a real team, and wouldn't be reset back to 0.0 by the update code because we never expect a neutral Capturable to be at 1.0 progress. This PR fixes that.