### PR TITLE
Make emitter burst independent of delta time

### DIFF
--- a/Source/Entities/AEJetpack.cpp
+++ b/Source/Entities/AEJetpack.cpp
@@ -195,7 +195,11 @@ void AEJetpack::Burst(Actor& parentActor, float fuelUseMultiplier) {
 	EnableEmission(true);
 	AlarmOnEmit(m_Team); // Jetpacks are noisy!
 
-	float fuelUsage = g_TimerMan.GetDeltaTimeMS() * static_cast<float>(std::max(GetTotalBurstSize(), 2)) * (CanTriggerBurst() ? 1.0F : 0.5F) * fuelUseMultiplier; // burst fuel
+	// TODO: burst emissions shouldn't be affected by delta time, but they sort of are.
+	// Hack here to use constant 60Hz deltatime in milliseconds.
+
+	float fuelUsage = (1000.0f / 60.0f) * static_cast<float>(std::max(GetTotalBurstSize(), 2)) * (CanTriggerBurst() ? 1.0F : 0.5F) * fuelUseMultiplier; // burst fuel
+
 	fuelUsage += g_TimerMan.GetDeltaTimeMS() * fuelUseMultiplier; // emit fuel
 	m_JetTimeLeft -= fuelUsage;
 }

--- a/Source/Entities/AEmitter.cpp
+++ b/Source/Entities/AEmitter.cpp
@@ -276,9 +276,14 @@ float AEmitter::EstimateImpulse(bool burst) {
 		for (Emission* emission: m_EmissionList) {
 			// Only check emissions that push the emitter
 			if (emission->PushesEmitter()) {
-				// Todo... we're not checking emission start/stop times here, so this will always calculate the impulse as if the emission was active.
+				// TODO: we're not checking emission start/stop times here, so this will always calculate the impulse as if the emission was active.
 				// There's not really an easy way to do this, since the emission rate is not necessarily constant over time.
-				float emissions = (emission->GetRate() / 60.0f) * g_TimerMan.GetDeltaTimeSecs();
+
+				// TODO: burst emissions shouldn't be affected by delta time, but they sort of are.
+				// Hack here to use constant 60Hz deltatime in seconds.
+				float deltaTimeSecs = burst ? 1.0f / 60.0f : g_TimerMan.GetDeltaTimeSecs();
+
+				float emissions = (emission->GetRate() / 60.0f) * deltaTimeSecs;
 				float scale = 1.0F;
 				if (burst) {
 					emissions *= emission->GetBurstSize();

--- a/Source/Entities/AHuman.cpp
+++ b/Source/Entities/AHuman.cpp
@@ -992,7 +992,9 @@ float AHuman::EstimateJumpHeight() const {
 		// Account for the forces upon us.
 		if (!hasBursted && fuelTime > 0.0F) {
 			currentYVelocity += impulseBurst;
-			fuelTime -= g_TimerMan.GetDeltaTimeMS() * fuelUseMultiplierBurst;
+			// TODO: burst emissions shouldn't be affected by delta time, but they sort of are.
+			// Hack here to use constant 60Hz deltatime in milliseconds.
+			fuelTime -= (1000.0f / 60.0f) * fuelUseMultiplierBurst;
 			hasBursted = true;
 		}
 


### PR DESCRIPTION
This code just replaces the value with 60Hz where it's used in relation to bursting. This is a bit of a hack, but it's the cleanest solution I can think of right now without going in and editing burst strength of everything lol

This makes total flight height consistent regardless of the delta time, at least as far as I can tell.

Old behavior: 

https://github.com/user-attachments/assets/3aca3a99-1ff7-41f5-aa95-0dae2c738a3e

New behavior:

https://github.com/user-attachments/assets/985ec618-098a-4d84-abba-078e9ae6a57a

I can still get somewhat higher flight height with smaller delta time, but I think it's just because it allows for higher grained precision burst spamming lol