### PR TITLE
MOPixel::Draw - don't skip drawing on non-drawn sim updates

### DIFF
--- a/Source/Entities/MOPixel.cpp
+++ b/Source/Entities/MOPixel.cpp
@@ -222,10 +222,8 @@ void MOPixel::Update() {
 }
 
 void MOPixel::Draw(BITMAP* targetBitmap, const Vector& targetPos, DrawMode mode, bool onlyPhysical) const {
-	// Don't draw color if this isn't a drawing frame
-	if (!g_TimerMan.DrawnSimUpdate() && mode == g_DrawColor) {
-		return;
-	}
+	// Note: don't skip this drawing even if it's not a drawn sim update and
+	// the DrawMode is g_DrawColor, because this might be a draw to a scene terrain.
 
 	int drawColor = -1;
 


### PR DESCRIPTION
MOPixels can be drawn onto the scene terrain in cases like digger particles settling. With this skip, digging with a `TimeScale` value more than 1 can cause those to skip rendering, accumulating ghost terrain that exists in material layer but not in color layer. Similar thing can happen with Constructor digging.

Without this fix (alternate terrain mode shown with RAlt+M): 

https://github.com/user-attachments/assets/15957168-346b-458b-9625-a9118b7b078a

With this fix: 

https://github.com/user-attachments/assets/817e7b82-14b1-41a6-aeff-4b20e5c5996a

I've also considered adding an extra check if this is drawing to scene terrain or not, but then I figured that this won't be reliable because what if we'll have multiple terrains in some weird future, or some other case where the target bitmap is persistent but isn't a scene terrain.