### PR TITLE
Meson Configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,21 @@
       "request": "launch",
       "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand",
       "cwd": "${workspaceFolder}",
+      "preLaunchTask": "Meson: Build all targets",
+      "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
+      "presentation": {
+        "group": "unix"
+      }
+    },
+    {
+      "name": "meson Configure Final & Launch",
+      "type": "cppdbg",
+      "osx": {
+        "MIMode": "lldb"
+      },
+      "request": "launch",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand",
+      "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Release",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
       "presentation": {
@@ -20,13 +35,13 @@
       }
     },
     {
-      "name": "meson Debug (Release)",
+      "name": "meson Debug (Release) & Launch",
       "type": "cppdbg",
       "osx": {
         "MIMode": "lldb"
       },
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand.debug.release",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Release)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
@@ -35,13 +50,13 @@
       }
     },
     {
-      "name": "meson Debug (Minimal)",
+      "name": "meson Debug (Minimal) & Launch",
       "type": "cppdbg",
       "osx": {
         "MIMode": "lldb"
       },
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand.debug.minimal",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Minimal)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
@@ -50,13 +65,13 @@
       }
     },
     {
-      "name": "meson Debug (Full)",
+      "name": "meson Debug (Full) & Launch",
       "type": "cppdbg",
       "osx": {
         "MIMode": "lldb"
       },
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand.debug.full",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Full)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
@@ -116,6 +131,18 @@
       "request": "launch",
       "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.exe",
       "cwd": "${workspaceFolder}",
+      "preLaunchTask": "Meson: Build all targets",
+      "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
+      "presentation": {
+        "group": "windows"
+      }
+    },
+    {
+      "name": "meson Configure Final & Launch [Windows]",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.exe",
+      "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Release",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
       "presentation": {
@@ -123,10 +150,10 @@
       }
     },
     {
-      "name": "meson Debug (Release) [Windows]",
+      "name": "meson Configure Debug (Release) & Launch [Windows]",
       "type": "cppvsdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.debug.release.exe",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.exe",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Release)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
@@ -135,10 +162,10 @@
       }
     },
     {
-      "name": "meson Debug (Minimal) [Windows]",
+      "name": "meson Configure Debug (Minimal) & Launch [Windows]",
       "type": "cppvsdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.debug.minimal.exe",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.exe",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Minimal)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
@@ -147,10 +174,10 @@
       }
     },
     {
-      "name": "meson Debug (Full) [Windows]",
+      "name": "meson Configure Debug (Full) & Launch [Windows]",
       "type": "cppvsdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.debug.full.exe",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/Cortex Command.exe",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Full)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand",
       "cwd": "${workspaceFolder}",
-      "preLaunchTask": "Meson: Build all targets",
+      "preLaunchTask": "meson Build Release",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
       "presentation": {
         "group": "unix"
@@ -26,7 +26,7 @@
         "MIMode": "lldb"
       },
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand_debug",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand.debug.release",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Release)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
@@ -41,7 +41,7 @@
         "MIMode": "lldb"
       },
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand_debug",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand.debug.minimal",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Minimal)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",
@@ -56,7 +56,7 @@
         "MIMode": "lldb"
       },
       "request": "launch",
-      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand_debug",
+      "program": "${workspaceFolder}/${config:mesonbuild.buildFolder}/CortexCommand.debug.full",
       "cwd": "${workspaceFolder}",
       "preLaunchTask": "meson Build Debug (Full)",
       "envFile": "${workspaceFolder}/${config:mesonbuild.buildFolder}/meson-vscode.env",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,7 @@
       }
     },
     {
-      "name": "meson Debug (Release) & Launch",
+      "name": "meson Configure Debug (Release) & Launch",
       "type": "cppdbg",
       "osx": {
         "MIMode": "lldb"
@@ -50,7 +50,7 @@
       }
     },
     {
-      "name": "meson Debug (Minimal) & Launch",
+      "name": "meson Configure Debug (Minimal) & Launch",
       "type": "cppdbg",
       "osx": {
         "MIMode": "lldb"
@@ -65,7 +65,7 @@
       }
     },
     {
-      "name": "meson Debug (Full) & Launch",
+      "name": "meson Configure Debug (Full) & Launch",
       "type": "cppdbg",
       "osx": {
         "MIMode": "lldb"

--- a/meson.build
+++ b/meson.build
@@ -51,16 +51,12 @@ if compiler.get_argument_syntax()== 'gcc' # used for gcc compatible compilers
       extra_args += ['-Wno-sign-compare', '-Wno-non-virtual-dtor', '-Wno-parentheses', '-Wno-overloaded-virtual', '-Wno-unused-variable', '-Wno-unused-function']
     endif
 
-    elfname += '.debug'
     debug_type = get_option('debug_type')
     if debug_type == 'release'
-      elfname += '.release'
       preprocessor_flags += ['-DRELEASE_BUILD'] # enable minimal debug features
     elif debug_type == 'minimal'
-      elfname += '.minimal'
       preprocessor_flags += ['-DMIN_DEBUG_BUILD', '-DDEBUGMODE'] # enable some debug features
     elif debug_type == 'full'
-      elfname += '.full'
       preprocessor_flags += ['-DDEBUG_BUILD', '-DDEBUGMODE'] # enable all debug features; may slow down game
     endif
   else
@@ -124,16 +120,12 @@ elif compiler.get_argument_syntax()== 'msvc'
   link_args+=['-ignore:4099', '-ignore:4217']
   buildtype_debug = get_option('debug')
   if buildtype_debug
-    elfname+='.debug'
     debug_type = get_option('debug_type')
     if debug_type == 'release'
-      elfname+='.release'
       preprocessor_flags += ['-DDEBUG_RELEASE_BUILD'] # enable minimal debug features
     elif debug_type == 'minimal'
-      elfname += '.minimal'
       preprocessor_flags += ['-DDEBUGMODE'] # enable some debug features
     elif debug_type == 'full'
-      elfname += '.full'
       preprocessor_flags += ['-DDEBUG_BUILD', '-DDEBUGMODE'] # enable all debug features; may slow down game
     endif
   else

--- a/meson.build
+++ b/meson.build
@@ -51,12 +51,16 @@ if compiler.get_argument_syntax()== 'gcc' # used for gcc compatible compilers
       extra_args += ['-Wno-sign-compare', '-Wno-non-virtual-dtor', '-Wno-parentheses', '-Wno-overloaded-virtual', '-Wno-unused-variable', '-Wno-unused-function']
     endif
 
+    elfname += '.debug'
     debug_type = get_option('debug_type')
     if debug_type == 'release'
+      elfname += '.release'
       preprocessor_flags += ['-DRELEASE_BUILD'] # enable minimal debug features
     elif debug_type == 'minimal'
+      elfname += '.minimal'
       preprocessor_flags += ['-DMIN_DEBUG_BUILD', '-DDEBUGMODE'] # enable some debug features
     elif debug_type == 'full'
+      elfname += '.full'
       preprocessor_flags += ['-DDEBUG_BUILD', '-DDEBUGMODE'] # enable all debug features; may slow down game
     endif
   else


### PR DESCRIPTION
Meson configurations should be generally usable now. Removed conditional builds from all Meson build paths, removed expectations of differentiated executables from Meson tasks, renamed all tasks to accurately read either "Launch" or "Configure & Launch" depending on specifics, and created parity. Now the project can be either built and run or configured, built, and run, for both Windows and Unix configurations.

I have neglected to gut the MSBuild stuff because I dunno exactly how to do that besides just cutting it from the `tasks.json` and `launch.json` files. That can be a separate PR, I think.