### PR TITLE
Weapon & Activity Script Fixes

### DIFF
--- a/Data/Base.rte/Activities/BunkerBreach.lua
+++ b/Data/Base.rte/Activities/BunkerBreach.lua
@@ -142,16 +142,16 @@ function BunkerBreach:SetupDefenderActors()
 	local crabToHumanSpawnRatio = self:GetCrabToHumanSpawnRatio(techID);
 
 	local loadoutNames = {"Light", "Heavy", "Sniper", "Engineer", "Mecha", "Turret"};
-	
+
 	local hasSpawnAreas = false;
 	for _, loadoutName in pairs(loadoutNames) do
 		if SceneMan.Scene:HasArea(loadoutName .. " Defenders") then
 			hasSpawnAreas = true;
 		end
 	end
-	
+
 	for actor in MovableMan.AddedActors do
-		if not actor:IsInGroup("Brains") and not actor:IsInGroup("Bunker Systems") then
+		if not actor:IsInGroup("Brains") and not actor:IsInGroup("Bunker Systems") and not IsADoor(actor) then
 			if hasSpawnAreas then
 				actor.ToDelete = true;
 			elseif actor.Team ~= self.defenderTeam then
@@ -162,7 +162,7 @@ function BunkerBreach:SetupDefenderActors()
 			actor.Team = self.defenderTeam;
 		end
 	end
-	
+
 	if hasSpawnAreas then
 		for _, loadoutName in pairs({"Light", "Heavy", "Sniper", "Engineer", "Mecha", "Turret"}) do
 			if SceneMan.Scene:HasArea(loadoutName .. " Defenders") then
@@ -261,7 +261,7 @@ function BunkerBreach:StartActivity(isNewGame)
 			FrameMan:ClearScreenText(self:ScreenOfPlayer(player));
 		end
 	end
-	
+
 	MusicMan:PlayDynamicSong("Generic Battle Music");
 
 	if isNewGame then
@@ -675,7 +675,7 @@ function BunkerBreach:CreateInternalReinforcements(loadout, numberOfReinforcemen
 					numberOfInternalReinforcementsToCreateAtPosition = 3;
 				end
 			end
-			
+
 			for i = 1, numberOfInternalReinforcementsToCreateAtPosition do
 				local internalReinforcement;
 				if loadout then

--- a/Data/Base.rte/Craft/Shared/AttachableTurret.lua
+++ b/Data/Base.rte/Craft/Shared/AttachableTurret.lua
@@ -56,7 +56,7 @@ function Update(self)
 				PrimitiveMan:DrawCirclePrimitive(self.Team, aimPos, (self.searchRange * 0.5), 13);
 			end
 			local aimTarget = MovableMan:GetClosestEnemyActor(self.Team, aimPos, (self.searchRange * 0.5), Vector());
-			if aimTarget and aimTarget.Status < Actor.INACTIVE then
+			if aimTarget and aimTarget.Status < Actor.INACTIVE and aimTarget.GetsHitByMOs then
 				--Debug: visualize search trace
 				if self.showAim then
 					PrimitiveMan:DrawLinePrimitive(self.Team, aimPos, aimTarget.Pos, 13);
@@ -89,7 +89,7 @@ function Update(self)
 			end
 
 			local color = 13;	--Debug trace color: red
-			if target and IsActor(target) and ToActor(target).Status < Actor.INACTIVE then
+			if target and IsActor(target) and ToActor(target).Status < Actor.INACTIVE and target.GetsHitByMOs then
 				self:EnableEmission(true);
 				self:TriggerBurst();
 				self.fireTimer:Reset();
@@ -106,7 +106,7 @@ function Update(self)
 			end
 		end
 	end
-	
+
 	if self.fireTimer:IsPastSimTimeLimit() then
 		self:EnableEmission(false);
 	end

--- a/Data/Browncoats.rte/Devices/Weapons/Flash/Flash.lua
+++ b/Data/Browncoats.rte/Devices/Weapons/Flash/Flash.lua
@@ -1,14 +1,14 @@
 function Create(self)
 	self.fireVel = 17;
 	self.spread = math.rad(self.ShakeRange);
-	
+
 	self.searchRange = 100 + FrameMan.PlayerScreenWidth * 0.3;
 	self.searchTimer = Timer();
 	self.searchTimer:SetSimTimeLimitMS(250);
 	self.lockThreshold = 2;
-	
+
 	self.targets = {};
-	
+
 	self.targetLockSound = CreateSoundContainer("Mine Activate", "Base.rte");
 end
 
@@ -45,16 +45,16 @@ function ThreadedUpdate(self)
 			end
 			if self.Magazine.RoundCount > 0 then
 				if controller:IsState(Controller.AIM_SHARP) then
-					
+
 					if self.searchTimer:IsPastSimTimeLimit() then
 						self.searchTimer:Reset();
-						
+
 						local searchPos = parent.ViewPoint;
 						local lastTargetCount = #self.targets;
 						self.targets = {};
 
 						for actor in MovableMan.Actors do
-							if #self.targets < self.RoundInMagCapacity and actor.Team ~= self.Team then
+							if #self.targets < self.RoundInMagCapacity and actor.Team ~= self.Team and actor.GetsHitByMOs then
 
 								if (SceneMan:ShortestDistance(searchPos, actor.Pos, SceneMan.SceneWrapsX).Magnitude - actor.Radius) < self.searchRange
 								and (actor.Vel.Magnitude + math.abs(actor.AngularVel) + 1)/math.sqrt(actor.Radius) < self.lockThreshold
@@ -99,7 +99,7 @@ function ThreadedUpdate(self)
 				if target.actor and target.actor.ID ~= rte.NoMOID then
 					local screen = ActivityMan:GetActivity():ScreenOfPlayer(ToActor(parent):GetController().Player);
 					PrimitiveMan:DrawBoxPrimitive(screen, target.actor.Pos + target.topLeft, target.actor.Pos + target.bottomRight, 149);
-					
+
 					if self.RoundInMagCount == 0 then
 						target.topLeft = target.topLeft * 0.9;
 						target.bottomRight = target.bottomRight * 0.9;

--- a/Data/Coalition.rte/Devices/Weapons/MissileLauncher/MissileLauncher.lua
+++ b/Data/Coalition.rte/Devices/Weapons/MissileLauncher/MissileLauncher.lua
@@ -43,7 +43,7 @@ function ThreadedUpdate(self)
 					local moCheck = SceneMan:GetMOIDPixel(hitPos.X, hitPos.Y);
 					if moCheck ~= rte.NoMOID then
 						local mo = ToMOSRotating(MovableMan:GetMOFromID(MovableMan:GetMOFromID(moCheck).RootID));
-						if mo and mo.ClassName ~= "ADoor" and mo.Team ~= parent.Team then
+						if mo and mo.ClassName ~= "ADoor" and mo.Team ~= parent.Team and mo.GetsHitByMOs then
 							local movement = (mo.Vel.Magnitude + math.abs(mo.AngularVel) + 0.1) * math.sqrt(mo.Radius);
 							if movement > self.lockThreshold then
 

--- a/Data/Techion.rte/Devices/Weapons/NucleoSwarm/NucleoSwarmShot.lua
+++ b/Data/Techion.rte/Devices/Weapons/NucleoSwarm/NucleoSwarmShot.lua
@@ -66,7 +66,7 @@ function Update(self)
 			self.seekerTimer:Reset();
 			self.seekerDelay = 1000 - math.random(1000);
 			for actor in MovableMan.Actors do
-				if actor.Team ~= self.Team then
+				if actor.Team ~= self.Team and actor.GetsHitByMOs then
 					self.potentialtargetdist = SceneMan:ShortestDistance(self.Pos, actor.Pos, SceneMan.SceneWrapsX);
 					if (self.lastdist == nil or (self.lastdist ~= nil and self.potentialtargetdist:MagnitudeIsLessThan(self.lastdist))) and not self.potentialtargetdist:MagnitudeIsGreaterThan(500) and SceneMan:CastStrengthRay(self.Pos, self.potentialtargetdist:SetMagnitude(self.potentialtargetdist.Magnitude - actor.Radius), 0, Vector(), 5, rte.airID, SceneMan.SceneWrapsX) == false then
 						self.lastdist = self.potentialtargetdist.Magnitude;

--- a/Data/Techion.rte/Devices/Weapons/NucleoSwarm/NucleoSwarmShot.lua
+++ b/Data/Techion.rte/Devices/Weapons/NucleoSwarm/NucleoSwarmShot.lua
@@ -21,7 +21,7 @@ function Create(self)
 			local moCheck = SceneMan:GetMOIDPixel(checkPos.X, checkPos.Y);
 			if moCheck ~= rte.NoMOID then
 				local actor = MovableMan:GetMOFromID(MovableMan:GetMOFromID(moCheck).RootID);
-				if actor and actor.Team ~= self.Team then
+				if actor and actor.Team ~= self.Team and actor.GetsHitByMOs then
 					self.target = actor;
 					break;
 				end
@@ -81,7 +81,7 @@ function Update(self)
 	if self.lifeTimer:IsPastSimMS(8000) then
 		self:GibThis();
 	end
-	
+
 	--TODO: Add wounds through Lua like the other disintegrator weapons
 	if SceneMan:GetTerrMatter(self.Pos.X, self.Pos.Y) == rte.airID then
 		local moCheck = SceneMan:GetMOIDPixel(self.Pos.X, self.Pos.Y);


### PR DESCRIPTION
Actually just two updates to fix things that bothered me when I was checking out the nightly build.

1. Bunker Breach now correctly spawns in door actors. More accurately, it no longer _deletes_ door actors, which it looks like it started doing because the actors themselves don't have the "Bunker Systems" group anymore. Not sure when that happened or how/if it should be fixed, but it looks like this is the only place that that check was being made, so I just added an IsADoor check and it works now.
2. Auto-targeting weapons (ML-02 Flash, Nucleo Swarm, Coalition Missile Launcher, Dropship turrets) no longer target actors with GetsHitByMOs set to false. This mainly affects mods that use "invisible" actors, like my Endless War/Breach mods, so this is a bit of a selfish one.