### PR TITLE
refactor: deduplicate Bresenham line algorithm into shared utility

### DIFF
--- a/.agents/skills/cortex-command-community-project/SKILL.md
+++ b/.agents/skills/cortex-command-community-project/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: cortex-command-community-project
+description: Use when working in the Cortex Command Community Project repository and you need fast subsystem routing, safe code change workflow, and reproducible build/debug validation on Debian, Ubuntu, or WSL2.
+---
+
+# Cortex Command Community Project
+
+## Overview
+
+Use this skill as the project operating manual for coding tasks in `Cortex-Command-Community-Project`.
+
+- Engine stack: C++20, Meson + Ninja, entry executable `CortexCommand`.
+- Runtime model: singleton managers (`g_*Man`) + `Entity` presets + Lua scripting.
+- First read for most tasks: `Source/Main.cpp`, `Source/Managers/PresetMan.*`, `Source/System/DataModule.*`.
+
+## Quick Start (Debian/Ubuntu/WSL2)
+
+Run from repository root.
+
+```bash
+sudo apt-get install build-essential libflac++-dev luajit-5.1-dev liblua5.1-dev libminizip-dev liblz4-dev libpng++-dev libtbb-dev ninja-build python3-pip
+sudo python3 -m pip install meson
+
+CC="ccache gcc" CXX="ccache g++" meson setup build-dev --reconfigure --buildtype=debug
+ninja -C build-dev
+
+./build-dev/CortexCommand
+./build-dev/CortexCommand -cout
+./build-dev/CortexCommand -ext-validate
+./build-dev/CortexCommand -module <SomeMod.rte>
+./build-dev/CortexCommand -editor <EditorName>
+```
+
+WSL notes:
+- WSL2 Ubuntu 22.04 is known-good.
+- Building from `/mnt/c/...` works, but Linux filesystem paths usually perform better.
+- Same Linux commands apply.
+
+## Architecture Map
+
+- `Source/Main.cpp`: process boot, manager init order, flags, loop dispatch, shutdown.
+- `Source/Managers/*`: global systems (window, frame, activity, scene, movable, audio, lua, presets, etc.).
+- `Source/Entities/*`: gameplay objects and simulation entities.
+- `Source/System/*`: serialization, IO, data modules, base utilities.
+- `Source/Lua/*`: Lua bindings/adapters.
+- `Data/*.rte/*`: official content modules.
+- `Mods/*.rte/*`: unofficial content modules.
+- `Userdata/*`: runtime/user-generated modules and saves.
+
+Boot sequence in `Source/Main.cpp`:
+1. Initialize SDL/Allegro and base system.
+2. Initialize managers in strict order.
+3. Parse launch flags.
+4. Load data modules (`g_PresetMan.LoadAllDataModules()`).
+5. Start menu/activity loops.
+6. Shutdown thread pools and managers cleanly.
+
+Game loop model (`RunGameLoop()`):
+- Event polling/input queueing.
+- Fixed-step simulation updates (Lua/input/frame/activity/scene/movables/audio).
+- Draw (`g_FrameMan.Draw()`) then post-process/upload (`g_WindowMan`).
+
+## Module and Content Loading Model
+
+- Official modules load first (`PresetMan::c_OfficialModules`).
+- Mods from `Mods/` load after official modules if enabled.
+- Userdata modules load last and may be auto-created.
+- INI definitions become `Entity` presets resolved through `PresetMan` + `DataModule`.
+
+When content fails to load:
+- Verify module order in `Source/Managers/PresetMan.cpp`.
+- Verify each module `Index.ini` include chain.
+- Verify class names and preset names match C++ registration/bindings.
+
+## Subsystem Routing Guide
+
+Use symptom-first routing:
+
+- Startup crash/black screen/quit deadlock -> `Source/Main.cpp`, `Source/Managers/WindowMan.*`, `Source/Managers/FrameMan.*`, `Source/Managers/ThreadMan.*`.
+- Missing mod/preset/content -> `Source/Managers/PresetMan.*`, `Source/System/DataModule.*`, affected `Data/*.rte` or `Mods/*.rte` files.
+- Input not responding/remap issues -> `Source/Main.cpp` (`PollSDLEvents`), `Source/Managers/UInputMan.*`, `Source/System/InputMapping.*`, `Source/System/InputScheme.*`, `Source/Menus/SettingsInput*.cpp`.
+- Visual artifacts/render-only issues -> `Source/Managers/FrameMan.*`, `Source/Managers/WindowMan.*`, `Source/Managers/PostProcessMan.*`, `Source/Renderer/*`.
+- Script callback/binding mismatch -> `Source/Managers/LuaMan.*`, `Source/Lua/LuaBindings*.cpp`, `Data/*/Scripts/*`.
+- Gameplay lifecycle/pause/restart bugs -> `Source/Managers/ActivityMan.*`, `Source/Activities/*`, `Source/Entities/Activity.*`.
+- Scene/object lifetime/collision bugs -> `Source/Managers/SceneMan.*`, `Source/Managers/MovableMan.*`, `Source/Entities/MovableObject.*`.
+- Audio/music behavior issues -> `Source/Managers/AudioMan.*`, `Source/Managers/MusicMan.*`, `Source/Entities/SoundContainer.*`, `Source/Entities/SoundSet.*`.
+
+## Key Manager Ownership Map
+
+- `WindowMan`/`FrameMan`/`PostProcessMan`: display state, frame composition, post effects.
+- `UInputMan`: runtime input ingestion and active-device behavior.
+- `AudioMan`/`MusicMan`: effect channels, panning, music transitions.
+- `ActivityMan`: activity lifecycle and state transitions.
+- `SceneMan`: terrain/scene lifecycle.
+- `MovableMan`: active movable object update/lifetime.
+- `PresetMan`: module discovery/order and preset registry lookup.
+- `LuaMan`: Lua states, dispatch, error propagation.
+- `MenuMan` + settings/menu GUIs: front-end flow and settings persistence.
+
+Treat ownership as routing guidance, not strict gatekeeping.
+
+## Common File Touchpoints By Issue Type
+
+- Boot or manager-order regressions: `Source/Main.cpp`, `Source/Managers/*`.
+- New configurable manager behavior: target `Source/Managers/<X>Man.*` + `Source/Managers/SettingsMan.*` + relevant `Source/Menus/Settings*.cpp`.
+- Entity behavior changes: `Source/Entities/*` + lifecycle managers (`MovableMan`, `SceneMan`, `ActivityMan`) + bindings if script-facing.
+- New/changed Lua API surface: `Source/Lua/LuaBindings*.cpp`, `Source/Lua/LuaAdapters.cpp`, `Source/Managers/LuaMan.*`.
+- Preset parsing/load problems: `Source/System/DataModule.*`, `Source/System/Reader.*`, `Source/Managers/PresetMan.*`, module `Index.ini` files.
+
+## Safe Implementation Workflow
+
+1. Restate player-visible outcome and choose a single primary subsystem.
+2. Reproduce first with exact steps and logs (`LogConsole.txt`, `LogLoading.txt`).
+3. Trace root cause before coding (manager order, load order, lifecycle boundaries, bindings).
+4. Apply minimal diff in scoped files; avoid cross-subsystem refactors unless required.
+5. If touching script-facing C++ behavior, update bindings and script/content callsites in same change.
+6. Rebuild and run targeted validation path plus core regressions.
+
+Scoping rules:
+- Prefer one player-visible behavior per ticket.
+- Avoid mixing rendering + gameplay + content in one PR unless tightly coupled.
+- Any `Main.cpp` or manager core change requires explicit regression checklist.
+
+## Debugging Checklist
+
+- Confirm whether bug is logic-step or render-step (fixed update vs draw path).
+- For startup failures, inspect manager init/shutdown ordering in `Source/Main.cpp`.
+- For content failures, inspect module order + include chain + preset/class name mismatches.
+- For scripting failures, verify Lua binding exists and script path actually executes.
+- For performance/jank spikes, inspect timer/performance managers and expensive loops in active subsystem.
+- Always compare before/after logs (`LogConsole.txt`, `LogLoading.txt`) for new warnings.
+
+## Validation Matrix
+
+Baseline for every PR:
+- Build succeeds: `ninja -C build-dev`.
+- Game reaches menu: `./build-dev/CortexCommand`.
+- At least one in-game scenario on affected path.
+- No new relevant log warnings/errors.
+
+Area-specific checks:
+- Input: keyboard + mouse + one gamepad path.
+- Modules/content: one official module path + one mod path.
+- Activity/gameplay: start -> pause -> resume -> restart -> exit.
+- Window/render: windowed + fullscreen + resolution change.
+- Lua/bindings: execute script path that calls changed API.
+
+## PR Readiness Checks
+
+- Ticket includes player-visible outcome, scope, and acceptance criteria.
+- Diff is scoped to declared subsystem(s) and avoids unrelated cleanup.
+- Repro steps are included for before and after behavior.
+- Validation evidence is present (commands run + scenario/menu path used).
+- Compatibility notes included when relevant (save/mod/performance risk).
+
+Priority shorthand:
+- `P0`: crash, startup failure, hard lock, data loss.
+- `P1`: major blocker/regression in common gameplay path.
+- `P2`: functional bug with workaround.
+- `P3`: polish/refactor/non-blocking improvement.
+
+## Work Intake Template
+
+Use this when creating implementation tickets:
+
+```md
+Title:
+
+Player-visible outcome:
+-
+
+Current behavior:
+-
+
+Scope:
+- In scope:
+- Out of scope:
+
+Likely subsystem(s):
+-
+
+Repro / validation path:
+1.
+2.
+3.
+
+Acceptance criteria:
+- [ ]
+- [ ]
+
+Risk notes:
+- Save compatibility?
+- Mod compatibility?
+- Performance risk?
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,168 @@
+# Cortex Command Community Project - Agent Map
+
+This file is a practical orientation guide for AI/code agents and non-game-dev contributors.
+It explains where things live, how the runtime flows, and where to make common changes safely.
+
+Companion docs:
+
+- `AGENTS_FEATURE_OWNERSHIP.md` - who owns what subsystem, key files, and test paths.
+- `AGENTS_WORK_INTAKE.md` - manager-friendly ticket template and assignment workflow.
+- `.agents/skills/cortex-command-community-project/SKILL.md` - reusable project skill payload.
+
+## 1) Quick context
+
+- Engine language: C++20
+- Main build system: Meson + Ninja (`meson.build` + `Source/**/meson.build`)
+- Entry executable: `CortexCommand`
+- Main entry point: `Source/Main.cpp`
+- Core architecture style: singleton managers (`g_*Man`) + `Entity` preset system + Lua scripting
+
+## 2) High-level repository layout
+
+- `Source/` - engine and game code
+  - `Activities/` - gameplay/editor activity logic (mission/session state)
+  - `Entities/` - most game object classes (actors, weapons, particles, terrain objects, scenes)
+  - `Managers/` - global systems (`WindowMan`, `FrameMan`, `AudioMan`, `SceneMan`, `MovableMan`, etc.)
+  - `Menus/` - title/menu/settings/pause UI screens
+  - `GUI/` - in-house GUI toolkit + wrappers + imgui integration
+  - `Lua/` - C++ <-> Lua bindings and adapters
+  - `Renderer/` - GL targets/shaders/draw pipeline helpers
+  - `System/` - base infrastructure (serialization, file IO, runtime type info, core math/util)
+- `Data/*.rte/` - official game content modules (INI/Lua/assets)
+- `Mods/` - third-party module folder (`*.rte` loaded from here)
+- `Userdata/` - runtime/user-generated modules and saves
+- `external/` - vendored dependencies, headers, third-party sources
+- `.github/workflows/` - CI build pipelines (Linux/macOS/Windows)
+
+## 3) Build wiring
+
+- Root `meson.build` configures compiler flags, dependencies, platform specifics, and links target executable.
+- `Source/meson.build` includes all code areas and pulls each subdirectory's `meson.build`.
+- Notable details:
+  - SDL3 is built from subproject on non-macOS.
+  - `LuaMan.cpp` is built as its own static library with permissive flags.
+  - Some modules are present in code but disabled in Meson lists (for example network and achievements in current config).
+
+## 4) Runtime boot sequence (important)
+
+Main flow is in `Source/Main.cpp`:
+
+1. Initialize Allegro/SDL and base `System`.
+2. Construct and initialize managers in a strict order (`InitializeManagers()`).
+3. Parse command-line flags (`-cout`, `-ext-validate`, `-module`, `-editor`).
+4. Load data modules (`g_PresetMan.LoadAllDataModules()`).
+5. Initialize menu/activity state and enter menu/game loops.
+6. Shutdown: wait for thread pools, destroy managers, quit SDL/Allegro.
+
+If something fails early, check manager init order and module loading first.
+
+## 5) Main game loop mental model
+
+`RunGameLoop()` has a fixed-step simulation pattern:
+
+- Poll SDL events -> queue input/window events.
+- Update window and frame timers.
+- While simulation step is due:
+  - update Lua, input, frame manager, console, activity, scene, movable objects, audio/music
+  - process activity state transitions (pause/menu/restart/resume)
+- Draw phase:
+  - `g_FrameMan.Draw()`
+  - post-process + upload via `g_WindowMan`
+
+This split is important when fixing "logic vs render" bugs.
+
+## 6) Most important systems and where to touch
+
+- Application/window/display:
+  - `Source/Managers/WindowMan.*`
+  - `Source/Managers/FrameMan.*`
+  - `Source/Renderer/*`
+- Input:
+  - `Source/Managers/UInputMan.*`
+  - SDL events are consumed in `PollSDLEvents()` in `Source/Main.cpp`
+- Audio/music:
+  - `Source/Managers/AudioMan.*`
+  - `Source/Managers/MusicMan.*`
+  - asset wrappers in `Source/Entities/SoundContainer.*`, `SoundSet.*`
+- Gameplay state:
+  - `Source/Managers/ActivityMan.*`
+  - concrete activities in `Source/Activities/*`
+- World and entities:
+  - `Source/Managers/SceneMan.*` (terrain/scene lifecycle)
+  - `Source/Managers/MovableMan.*` (active movable objects)
+  - `Source/Entities/*` (core object hierarchy)
+- Data and mod content:
+  - `Source/Managers/PresetMan.*`
+  - `Source/System/DataModule.*`
+  - content in `Data/*.rte/*` and `Mods/*.rte/*`
+- Scripting:
+  - `Source/Managers/LuaMan.*`
+  - bindings in `Source/Lua/LuaBindings*.cpp`
+
+## 7) Content/module loading model
+
+- Official modules are loaded first from `PresetMan::c_OfficialModules`.
+- Unofficial modules are loaded from `Mods/` if enabled.
+- Userdata modules are loaded last (auto-created if missing).
+- INI-driven definitions become `Entity` presets and are resolved through `PresetMan`/`DataModule`.
+
+When debugging "missing asset/preset" issues, inspect:
+
+- module order in `Source/Managers/PresetMan.cpp`
+- module `Index.ini` and include chain
+- class/type name and preset name mismatches
+
+## 8) Core code patterns to expect
+
+- Singleton access macros: `g_WindowMan`, `g_SceneMan`, etc.
+- Reflection-like registration and pooled allocation via `Entity::ClassInfo` macros in `Source/System/Entity.h`.
+- Serialization via `Serializable` + `Reader`/`Writer` (`Source/System/Serializable.h`, `Reader.*`, `Writer.*`).
+- Heavy usage of ownership comments in headers; trust those comments when changing pointer logic.
+
+## 9) Fast paths for common tasks
+
+- Add or modify gameplay object behavior:
+  1. Edit class in `Source/Entities/`.
+  2. Update manager interactions if lifecycle changes (`MovableMan`, `SceneMan`, `ActivityMan`).
+  3. If script-facing, update `Source/Lua/LuaBindings*.cpp`.
+- Add a new manager-level feature:
+  1. Implement in relevant `Source/Managers/*`.
+  2. Wire init/update/shutdown in `Source/Main.cpp` if needed.
+  3. Add settings plumbing in `SettingsMan` when configurable.
+- Add or adjust content:
+  1. Edit module `Data/<Module>.rte/Index.ini` and included INIs/Lua.
+  2. Validate type/preset names against C++ bindings.
+  3. Launch game and watch loading logs.
+
+## 10) Useful local commands
+
+- Incremental rebuild: `ninja -C build-dev`
+- Run game: `./build-dev/CortexCommand`
+- Reconfigure debug build:
+  - `CC="ccache gcc" CXX="ccache g++" meson setup build-dev --reconfigure --buildtype=debug`
+- Optional command-line diagnostics:
+  - `./build-dev/CortexCommand -cout`
+  - `./build-dev/CortexCommand -ext-validate`
+  - `./build-dev/CortexCommand -module <SomeMod.rte>`
+  - `./build-dev/CortexCommand -editor <EditorName>`
+
+## 11) Good first files for any investigation
+
+1. `Source/Main.cpp`
+2. `Source/Managers/ActivityMan.*`
+3. `Source/Managers/PresetMan.*`
+4. `Source/System/DataModule.*`
+5. `Source/Managers/SceneMan.*`
+6. `Source/Managers/MovableMan.*`
+7. `Source/Managers/LuaMan.*`
+
+## 12) Notes for manager-style collaboration
+
+- Ask for changes in terms of gameplay outcome ("what player should experience"), then map to systems.
+- Prefer small, verifiable slices: one subsystem at a time.
+- For each task, define:
+  - expected player-visible behavior
+  - affected module(s)
+  - how to validate (menu path, scenario, log, repro steps)
+
+That keeps implementation focused and reviewable even without deep engine internals knowledge.

--- a/AGENTS_FEATURE_OWNERSHIP.md
+++ b/AGENTS_FEATURE_OWNERSHIP.md
@@ -1,0 +1,103 @@
+# Cortex Command - Feature Ownership Map
+
+Use this file to route tasks fast when you are assigning work.
+Each area lists the primary code owners (systems/files), common change types, and quick validation paths.
+
+## 1) Engine boot, loop, and app lifecycle
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Boot/shutdown and loops | `Source/Main.cpp` | startup flags, manager order, loop transitions, global flow bugs | launch game, enter menu, start mission, exit cleanly |
+| Timers/perf cadence | `Source/Managers/TimerMan.*`, `Source/Managers/PerformanceMan.*` | fixed-step timing, sim pacing, perf counters | observe FPS/MSPF/MSPSU behavior in debug tools |
+| Global thread orchestration | `Source/Managers/ThreadMan.*` | task queue behavior, pool sizing, shutdown waits | no deadlocks on quit, no stalled async tasks |
+
+## 2) Window, rendering, and post-process
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Window/display state | `Source/Managers/WindowMan.*` | fullscreen, resolution changes, vsync, display handling | resize/fullscreen toggle from settings |
+| Frame composition | `Source/Managers/FrameMan.*` | draw order, split-screen layout, overlays, framebuffer behavior | menu + in-game draw correctness, split-screen |
+| GL resources/pipeline | `Source/Managers/GLResourceMan.*`, `Source/Renderer/*` | texture/shader lifetime, render target behavior, draw helpers | load scene, camera movement, effects visible |
+| Post effects | `Source/Managers/PostProcessMan.*`, `Data/Base.rte/Shaders/*` | post-processing settings/effects | toggle visual settings and compare output |
+
+## 3) Input and controls
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Input event ingestion | `Source/Main.cpp` (`PollSDLEvents`), `Source/Managers/UInputMan.*` | keyboard/mouse/gamepad event handling, focus rules | navigate menus + play with each input type |
+| Input mapping/config | `Source/System/InputMapping.*`, `Source/System/InputScheme.*`, `Source/Menus/SettingsInput*.cpp` | remapping UX, deadzones, keybind persistence | remap controls, restart, verify persisted mapping |
+| Device icons and UI hints | `Source/Managers/UInputMan.*`, `Data/Base.rte/GUIs*` | icon sets and active device display | switch device, check icon updates in menus |
+
+## 4) Audio and music
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Audio backend | `Source/Managers/AudioMan.*` | channel behavior, panning, priorities, global pitch | play mission with many effects and monitor audio stability |
+| Music behavior | `Source/Managers/MusicMan.*`, `Source/Entities/DynamicSong.*` | transitions, context music, silence/fade logic | start/stop activities, pause/resume, check music state |
+| Sound assets integration | `Source/Entities/SoundContainer.*`, `Source/Entities/SoundSet.*`, `Data/*/Sounds*` | new sound definitions, runtime playback wiring | trigger object actions that play affected sounds |
+
+## 5) Gameplay state and activities
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Activity lifecycle | `Source/Managers/ActivityMan.*`, `Source/Entities/Activity.*` | start/pause/resume/restart flow, save/load behavior | menu -> mission -> pause -> resume -> restart |
+| Scripted activities | `Source/Activities/GAScripted.*`, `Data/*/Activities*`, activity Lua | mission rules, scripted events | run target scenario and follow repro script |
+| Editors (in-game tools) | `Source/Activities/*Editor*`, `Source/Menus/*EditorGUI*` | scene/actor/area editing workflows | launch via `-editor <EditorName>` and test actions |
+
+## 6) World simulation and entities
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Scene/terrain lifecycle | `Source/Managers/SceneMan.*`, `Source/Entities/Scene.*`, `Source/Entities/SLTerrain.*` | terrain loading, placement, background/layer behavior | load several scenes, check placement and terrain state |
+| Movable object runtime | `Source/Managers/MovableMan.*`, `Source/Entities/MovableObject.*` | update loops, collision side effects, object lifetime | spawn combat-heavy scene, monitor crashes/desyncs |
+| Actor/device behavior | `Source/Entities/AHuman.*`, `ACrab.*`, `HDFirearm.*`, `ThrownDevice.*`, `TDExplosive.*` | unit logic, weapon handling, damage/explosion behavior | sandbox scenario with targeted actor/device interactions |
+| Materials/physics helpers | `Source/Entities/Material.*`, `Source/System/SpatialPartitionGrid.*`, `Source/System/PathFinder.*` | terrain/material interactions, broad-phase or pathing | stress test AI movement and terrain destruction |
+
+## 7) Data modules, presets, and mod loading
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Module discovery/order | `Source/Managers/PresetMan.*` | load order, official/mod/userdata handling, single-module mode | run with default + `-module <Mod.rte>` |
+| Module parsing | `Source/System/DataModule.*`, `Source/System/Reader.*` | `Index.ini` processing, include traversal, metadata parsing | introduce controlled bad/good ini and check logs |
+| Preset lookup and reflection | `Source/System/Entity.*`, `Source/Managers/PresetMan.*` | type registration, preset fetch errors, clone/memory pool logic | boot and load activity that touches changed presets |
+| Content definitions | `Data/*.rte/*.ini`, `Data/*.rte/*.lua`, `Mods/*.rte/*` | balancing, loadouts, object defs, scenario content | run affected faction/activity and verify assets |
+
+## 8) Lua runtime and bindings
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Lua state/runtime | `Source/Managers/LuaMan.*` | threaded states, script dispatch, error propagation | trigger scripted entities, watch console/log warnings |
+| C++ bindings | `Source/Lua/LuaBindings*.cpp`, `Source/Lua/LuaAdapters.cpp` | expose methods/types/properties to scripts | write small test script that calls new API |
+| Script assets | `Data/*/Scripts/*`, `Data/Base.rte/LuaIntegration/*` | gameplay script behavior or utility updates | reproduce script path and verify expected side effects |
+
+## 9) Menus and UI
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Menu state machine | `Source/Managers/MenuMan.*`, `Source/Menus/TitleScreen.*`, `MainMenuGUI.*`, `PauseMenuGUI.*` | transitions, menu behavior, flow control | boot sequence, scenario selection, pause/unpause |
+| Settings pages | `Source/Menus/Settings*.cpp`, `Source/Managers/SettingsMan.*` | new options, value clamping, persistence | change option, restart game, verify persisted value |
+| GUI framework | `Source/GUI/*`, `Source/GUI/Wrappers/*` | controls, skinning, event routing | navigate complex menus, check interactions and layout |
+
+## 10) Networking (currently mostly disabled in Meson)
+
+| Area | Primary files | Typical changes | Validate |
+|---|---|---|---|
+| Client/server managers | `Source/Managers/NetworkClient.*`, `Source/Managers/NetworkServer.*` | protocol behavior and connection lifecycle | requires enabling in build and multiplayer test harness |
+| Multiplayer activity/ui | `Source/Activities/MultiplayerGame.*`, `Source/Menus/MultiplayerGameGUI.*` | multiplayer flow and UI behavior | host/join smoke test after build integration |
+
+Note: network-related sources are present but commented out in current Meson lists. Account for that before assigning networking tasks.
+
+## 11) Assignment shortcuts (manager view)
+
+- If bug mentions startup/crash before menu: assign to boot/lifecycle (`Source/Main.cpp`, manager init).
+- If bug mentions missing preset/mod/content: assign to `PresetMan` + `DataModule` + relevant `Data/*.rte`.
+- If bug mentions control not responding: assign to `UInputMan` + settings input GUIs.
+- If bug is visual only (no gameplay impact): assign to `WindowMan`/`FrameMan`/`Renderer`.
+- If bug is scripted behavior mismatch: assign to Lua bindings/runtime + script assets.
+
+## 12) Standard acceptance checks for any subsystem ticket
+
+1. Repro case before change and after change.
+2. No regressions on startup, entering mission, pausing, and quitting.
+3. Logs checked for new warnings/errors (`LogConsole.txt`, `LogLoading.txt`).
+4. If data/module touched, verify at least one official activity and one mod loading path.

--- a/AGENTS_WORK_INTAKE.md
+++ b/AGENTS_WORK_INTAKE.md
@@ -1,0 +1,96 @@
+# Cortex Command - Work Intake Playbook
+
+Manager-focused template for opening tasks that are easy to implement and verify.
+
+## 1) Ticket template (copy/paste)
+
+Use this format when assigning work:
+
+```md
+Title:
+
+Player-visible outcome:
+- What should the player notice after this is done?
+
+Current behavior:
+- What happens now?
+
+Scope:
+- In scope:
+- Out of scope:
+
+Likely subsystem(s):
+- (pick from AGENTS_FEATURE_OWNERSHIP.md)
+
+Repro / validation path:
+1.
+2.
+3.
+
+Acceptance criteria:
+- [ ]
+- [ ]
+
+Risk notes:
+- Save compatibility?
+- Mod compatibility?
+- Performance risk?
+```
+
+## 2) How to choose subsystem owner quickly
+
+- "Cannot launch / black screen / crash on boot" -> Boot/Window/Frame owners.
+- "My mod item does not load" -> Preset/DataModule owners (+ content author).
+- "Weapon/actor behavior wrong" -> Entity/Activity owners.
+- "Input binding or controller issue" -> UInput/InputMapping owners.
+- "Menu/settings flow issue" -> MenuMan/Settings GUI owners.
+- "Script callback not firing" -> LuaMan/Bindings owners.
+- "Visual artifact only" -> Renderer/PostProcess owners.
+
+## 3) Scoping rules that prevent churn
+
+- Define one player-visible behavior per ticket when possible.
+- Do not combine rendering + gameplay + content edits in one task unless required.
+- If touching `Data/*.rte`, call out whether change is balance/content or engine logic.
+- If touching engine core (`Main.cpp`, managers), require a short regression checklist.
+
+## 4) Required validation checklist per PR
+
+Minimum checks:
+
+1. Build passes (`ninja -C build-dev`).
+2. Game boots to menu (`./build-dev/CortexCommand`).
+3. One in-game scenario/activity run for the changed area.
+4. No new warnings in relevant logs (`LogConsole.txt`, `LogLoading.txt`).
+
+Additional checks by area:
+
+- Input changes: keyboard + mouse + at least one gamepad path.
+- Module/content changes: official module path + one mod path.
+- Activity/gameplay changes: pause/resume/restart flow.
+- Render/window changes: windowed + fullscreen and resolution change.
+
+## 5) Priority model
+
+- P0: crash/data loss/hard lock/startup failure.
+- P1: major gameplay blocker or severe regression in common path.
+- P2: functional bug with workaround, or moderate UX degradation.
+- P3: polish/refactor/non-blocking improvement.
+
+## 6) Definition of done (manager view)
+
+A task is done when all are true:
+
+- behavior matches the "player-visible outcome"
+- acceptance criteria are checked
+- validation steps are reproducible by another person
+- no unexplained side effects in logs
+- change list is scoped to declared subsystem(s)
+
+## 7) Suggested task size
+
+- Small: 1-3 files, one subsystem, same-day.
+- Medium: 4-10 files, one major subsystem plus UI/content touches.
+- Large: multi-subsystem architecture or behavior overhaul; split into milestones.
+
+For large work, request an implementation plan first, then approve milestone by milestone.

--- a/Source/GUI/GUIListPanel.cpp
+++ b/Source/GUI/GUIListPanel.cpp
@@ -697,6 +697,9 @@ void GUIListPanel::SetMouseScrolling(bool mouseScroll) {
 
 void GUIListPanel::ScrollBarScrolling(int mouseWheelChange) {
 	int newValue = 0;
+	if (GetItemList()->empty()) {
+		return;
+	}
 	Item* lastItem = GetItem(GetItemList()->size() - 1);
 	int avgItemHeight = static_cast<int>((GetStackHeight(lastItem) + GetItemHeight(lastItem)) / GetItemList()->size());
 	if (mouseWheelChange < 0) {

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -352,7 +352,9 @@ void RunGameLoop() {
 
 			g_LuaMan.ClearScriptTimings();
 			g_MovableMan.Update();
-			g_PerformanceMan.UpdateSortedScriptTimings(g_LuaMan.GetScriptTimings());
+			if (g_PerformanceMan.IsShowingPerformanceStats()) {
+				g_PerformanceMan.UpdateSortedScriptTimings(g_LuaMan.GetScriptTimings());
+			}
 
 			g_AudioMan.Update();
 			g_MusicMan.Update();

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -346,6 +346,8 @@ void RunGameLoop() {
 			g_ConsoleMan.Update();
 			g_ActivityMan.Update();
 
+			g_UInputMan.HandleSpecialInput();
+
 			if (g_SceneMan.GetScene()) {
 				g_SceneMan.GetScene()->Update();
 			}

--- a/Source/Managers/ActivityMan.cpp
+++ b/Source/Managers/ActivityMan.cpp
@@ -25,8 +25,8 @@
 
 #include "MusicMan.h"
 
-#include "zip.h"
-#include "unzip.h"
+#include "minizip/zip.h"
+#include "minizip/unzip.h"
 
 #include "tracy/Tracy.hpp"
 

--- a/Source/Managers/ActivityMan.cpp
+++ b/Source/Managers/ActivityMan.cpp
@@ -25,8 +25,13 @@
 
 #include "MusicMan.h"
 
-#include "minizip/zip.h"
-#include "minizip/unzip.h"
+#ifdef SYSTEM_MINIZIP
+#include <minizip/zip.h>
+#include <minizip/unzip.h>
+#else
+#include "zip.h"
+#include "unzip.h"
+#endif
 
 #include "tracy/Tracy.hpp"
 

--- a/Source/Managers/AudioMan.cpp
+++ b/Source/Managers/AudioMan.cpp
@@ -170,14 +170,14 @@ void AudioMan::Update() {
 					if (IsInMultiplayerMode()) {
 						humanPlayerPosition += (Vector(static_cast<float>(g_FrameMan.GetPlayerFrameBufferWidth(screen)), static_cast<float>(g_FrameMan.GetPlayerFrameBufferHeight(screen))) / 2);
 					}
-					m_CurrentActivityHumanPlayerPositions.push_back(std::make_unique<const Vector>(humanPlayerPosition));
+					m_CurrentActivityHumanPlayerPositions.push_back(humanPlayerPosition);
 				}
 			}
 
 			int listenerNumber = 0;
-			for (const std::unique_ptr<const Vector>& humanPlayerPosition: m_CurrentActivityHumanPlayerPositions) {
+			for (const Vector& humanPlayerPosition: m_CurrentActivityHumanPlayerPositions) {
 				if (status == FMOD_OK) {
-					FMOD_VECTOR playerPosition = GetAsFMODVector(*(humanPlayerPosition.get()), m_ListenerZOffset);
+					FMOD_VECTOR playerPosition = GetAsFMODVector(humanPlayerPosition, m_ListenerZOffset);
 					status = m_AudioSystem->set3DListenerAttributes(listenerNumber, &playerPosition, nullptr, &c_FMODForward, &c_FMODUp);
 				}
 				listenerNumber++;
@@ -669,7 +669,7 @@ void AudioMan::Update3DEffectsForSFXChannels() {
 			float channel3dLevel;
 			result = (result == FMOD_OK) ? soundChannel->get3DLevel(&channel3dLevel) : result;
 			if (result == FMOD_OK && m_CurrentActivityHumanPlayerPositions.size() == 1) {
-				float sqrDistanceToPlayer = (*(m_CurrentActivityHumanPlayerPositions[0].get()) - GetAsVector(channelPosition)).GetSqrMagnitude();
+				float sqrDistanceToPlayer = (m_CurrentActivityHumanPlayerPositions[0] - GetAsVector(channelPosition)).GetSqrMagnitude();
 				float doubleMinimumDistanceForPanning = m_MinimumDistanceForPanning * 2.0F;
 				void* userData;
 				result = result == FMOD_OK ? soundChannel->getUserData(&userData) : result;
@@ -730,9 +730,9 @@ FMOD_RESULT AudioMan::UpdatePositionalEffectsForSoundChannel(FMOD::Channel* soun
 
 	float sqrShortestDistance = c_SoundMaxAudibleDistance * c_SoundMaxAudibleDistance;
 	float sqrLongestDistance = 0.0F;
-	for (const std::unique_ptr<const Vector>& humanPlayerPosition: m_CurrentActivityHumanPlayerPositions) {
+	for (const Vector& humanPlayerPosition: m_CurrentActivityHumanPlayerPositions) {
 		for (const FMOD_VECTOR& wrappedChannelPosition: wrappedChannelPositions) {
-			float sqrDistanceToChannelPosition = (*(humanPlayerPosition.get()) - GetAsVector(wrappedChannelPosition)).GetSqrMagnitude();
+			float sqrDistanceToChannelPosition = (humanPlayerPosition - GetAsVector(wrappedChannelPosition)).GetSqrMagnitude();
 			if (sqrDistanceToChannelPosition < sqrShortestDistance) {
 				sqrShortestDistance = sqrDistanceToChannelPosition;
 				channelPosition = wrappedChannelPosition;

--- a/Source/Managers/AudioMan.h
+++ b/Source/Managers/AudioMan.h
@@ -328,7 +328,7 @@ namespace RTE {
 		FMOD::ChannelGroup* m_MusicChannelGroup; //!< The FMOD ChannelGroup for music.
 
 		bool m_AudioEnabled; //!< Bool to tell whether audio is enabled or not.
-		std::vector<std::unique_ptr<const Vector>> m_CurrentActivityHumanPlayerPositions; //!< The stored positions of each human player in the current activity. Only filled when there's an activity running.
+		std::vector<Vector> m_CurrentActivityHumanPlayerPositions; //!< The stored positions of each human player in the current activity. Only filled when there's an activity running.
 		std::unordered_map<int, float> m_SoundChannelMinimumAudibleDistances; //!<  An unordered map of sound channel indices to floats representing each Sound Channel's minimum audible distances. This is necessary to keep safe data in case the SoundContainer is destroyed while the sound is still playing, as happens often with TDExplosives.
 
 		bool m_MuteMaster; //!< Whether all the audio is muted.

--- a/Source/Managers/FrameMan.cpp
+++ b/Source/Managers/FrameMan.cpp
@@ -17,6 +17,7 @@
 #include "SLBackground.h"
 #include "Scene.h"
 #include "System.h"
+#include "System/BresenhamLine.h"
 
 #include "RenderTarget.h"
 
@@ -653,94 +654,49 @@ int FrameMan::SharedDrawLine(BITMAP* bitmap, const Vector& start, const Vector& 
 		RTEAssert(dot, "Trying to draw line of dots without specifying a dot Bitmap");
 	}
 
-	int error = 0;
-	int dom = 0;
-	int sub = 0;
-	int domSteps = 0;
 	int skipped = skip + (skipStart - skip);
-	int intPos[2];
-	int delta[2];
-	int delta2[2];
-	int increment[2];
 	bool drawAlt = false;
 
 	int dotHeight = drawDot ? dot->h : 0;
 	int dotWidth = drawDot ? dot->w : 0;
-
-	// acquire_bitmap(bitmap);
 
 	// Just make the alt the same color as the main one if no one was specified
 	if (altColor == 0) {
 		altColor = color;
 	}
 
-	intPos[X] = start.GetFloorIntX();
-	intPos[Y] = start.GetFloorIntY();
+	int startX = start.GetFloorIntX();
+	int startY = start.GetFloorIntY();
+	int endX = shortestWrap ? g_SceneMan.ShortestDistance(start, end, false).GetFloorIntX() : end.GetFloorIntX();
+	int endY = shortestWrap ? g_SceneMan.ShortestDistance(start, end, false).GetFloorIntY() : end.GetFloorIntY();
 
-	// Wrap line around the scene if it makes it shorter
-	if (shortestWrap) {
-		Vector deltaVec = g_SceneMan.ShortestDistance(start, end, false);
-		delta[X] = deltaVec.GetFloorIntX();
-		delta[Y] = deltaVec.GetFloorIntY();
-	} else {
-		delta[X] = end.GetFloorIntX() - intPos[X];
-		delta[Y] = end.GetFloorIntY() - intPos[Y];
-	}
-	if (delta[X] == 0 && delta[Y] == 0) {
+	if (startX == endX && startY == endY) {
 		return 0;
 	}
 
-	// Bresenham's line drawing algorithm preparation
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else {
-		increment[X] = 1;
-	}
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else {
-		increment[Y] = 1;
-	}
+	drawAlt = false;
+	skipped = skipStart;
 
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-	error = delta2[sub] - delta[dom];
-
-	// Bresenham's line drawing algorithm execution
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
-		}
-		error += delta2[sub];
-
-		// Only draw pixel if we're not due to skip any
+	TraverseBresenhamLine(
+	    startX, startY,
+	    endX, endY,
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
 		if (++skipped > skip) {
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
+			if (shortestWrap) {
+				g_SceneMan.WrapPosition(x, y);
+			}
 
 			if (drawDot) {
-				masked_blit(dot, bitmap, 0, 0, intPos[X] - (dotWidth / 2), intPos[Y] - (dotHeight / 2), dot->w, dot->h);
+				masked_blit(dot, bitmap, 0, 0, x - (dotWidth / 2), y - (dotHeight / 2), dot->w, dot->h);
 			} else {
-				putpixel(bitmap, intPos[X], intPos[Y], drawAlt ? color : altColor);
+				putpixel(bitmap, x, y, drawAlt ? altColor : color);
 			}
 			drawAlt = !drawAlt;
 			skipped = 0;
 		}
-	}
+		return true;
+	    });
 
 	// Return the end phase state of the skipping
 	return skipped;

--- a/Source/Managers/SceneMan.cpp
+++ b/Source/Managers/SceneMan.cpp
@@ -18,6 +18,8 @@
 #include "Material.h"
 #include "SoundContainer.h"
 
+#include "System/BresenhamLine.h"
+
 #include "tracy/Tracy.hpp"
 
 using namespace RTE;
@@ -818,69 +820,24 @@ std::vector<MOPixel*>* SceneMan::DislodgePixelBoxNoBool(const Vector& upperLeftC
 
 std::vector<MOPixel*>* SceneMan::DislodgePixelLine(const Vector& start, const Vector& ray, int skip, bool deletePixels) {
 	std::vector<MOPixel*>* pixelList = new std::vector<MOPixel*>();
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
 
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
+	int endX = std::floor(start.m_X + ray.m_X);
+	int endY = std::floor(start.m_Y + ray.m_Y);
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    endX, endY,
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
-
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
+		MOPixel* px = DislodgePixelBool(x, y, deletePixels);
+		if (px) {
+			pixelList->push_back(px);
 		}
-		error += delta2[sub];
 
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			MOPixel* px = DislodgePixelBool(intPos[X], intPos[Y], deletePixels);
-			if (px) {
-				pixelList->push_back(px);
-			}
-
-			// Reset skip counter
-			skipped = 0;
-		}
-	}
+		return true;
+	    });
 
 	return pixelList;
 }
@@ -1040,196 +997,77 @@ void SceneMan::RestoreUnseenBox(const int posX, const int posY, const int width,
 }
 
 bool SceneMan::CastTerrainPenetrationRay(const Vector& start, const Vector& ray, Vector& endPos, int strengthLimit, int skip) {
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	bool stopped = false;
-	unsigned char materialID;
-	Material const* foundMaterial;
 	int totalStrength = 0;
-	// Save the projected end of the ray pos
 	endPos = start + ray;
 
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
+	bool stopped = TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] == 0 && delta[Y] == 0)
-		return false;
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
-
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
-
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
+		Material const* foundMaterial = GetMaterialFromID(GetTerrMatter(x, y));
+		totalStrength += foundMaterial->GetIntegrity();
+		if (totalStrength >= strengthLimit) {
+			endPos.SetXY(x, y);
+			return false;
 		}
-		error += delta2[sub];
 
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			// Check the strength of the terrain to see if we can penetrate further
-			materialID = GetTerrMatter(intPos[X], intPos[Y]);
-			// Get the material object
-			foundMaterial = GetMaterialFromID(materialID);
-			// Add the encountered material's strength to the tally
-			totalStrength += foundMaterial->GetIntegrity();
-			// See if we have hit the limits of our ray's strength
-			if (totalStrength >= strengthLimit) {
-				// Save the position of the end of the ray where blocked
-				endPos.SetXY(intPos[X], intPos[Y]);
-				stopped = true;
-				break;
-			}
-			// Reset skip counter
-			skipped = 0;
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-			}
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
 		}
-	}
+		return true;
+	    });
 
 	return stopped;
 }
 
-// TODO Every raycast should use some shared line drawing method (or maybe something more efficient if it exists, that needs looking into) instead of having a ton of duplicated code.
 bool SceneMan::CastUnseenRay(int team, const Vector& start, const Vector& ray, Vector& endPos, int strengthLimit, int skip, bool reveal) {
 	if (!m_pCurrentScene->GetUnseenLayer(team))
 		return false;
 
-	int error, dom, sub, domSteps, skipped = skip;
-	int size = 40 - GetUnseenResolution(team).GetLargest();
-	int intPos[2], delta[2], delta2[2], increment[2];
-	bool affectedAny = false;
-	unsigned char materialID;
-	Material const* foundMaterial;
-	int totalStrength = 0;
-	// Save the projected end of the ray pos
-	endPos = start + ray;
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0)
+	if (!m_pCurrentScene)
 		return false;
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	int size = 40 - GetUnseenResolution(team).GetLargest();
+	bool affectedAny = false;
+	int totalStrength = 0;
+	endPos = start + ray;
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		WrapPosition(x, y);
 
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
+		bool is_unseen = IsUnseen(x, y, team) || IsUnseen(x - size, y - size, team) || IsUnseen(x + size, y - size, team) || IsUnseen(x + size, y + size, team) || IsUnseen(x - size, y + size, team) || IsUnseen(x - size, y, team) || IsUnseen(x + size, y, team) || IsUnseen(x, y - size, team) || IsUnseen(x, y + size, team);
 
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
-		}
-		error += delta2[sub];
-
-		// Only check space if we're not due to skip any, or if this is the last step
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping
-			WrapPosition(intPos[X], intPos[Y]);
-
-			bool is_unseen = IsUnseen(intPos[X], intPos[Y], team) || IsUnseen(intPos[X] - size, intPos[Y] - size, team) || IsUnseen(intPos[X] + size, intPos[Y] - size, team) || IsUnseen(intPos[X] + size, intPos[Y] + size, team) || IsUnseen(intPos[X] - size, intPos[Y] + size, team) || IsUnseen(intPos[X] - size, intPos[Y], team) || IsUnseen(intPos[X] + size, intPos[Y], team) || IsUnseen(intPos[X], intPos[Y] - size, team) || IsUnseen(intPos[X], intPos[Y] + size, team);
-
-			// Reveal if we can, save the result
-			if (reveal) {
-				if (is_unseen) {
-					RevealUnseenBox(intPos[X] - size / 2, intPos[Y] - size / 2, size, size, team);
-					affectedAny = true;
-				}
-			} else {
-				if (!is_unseen) {
-					RestoreUnseenBox(intPos[X] - size / 2, intPos[Y] - size / 2, size, size, team);
-					affectedAny = true;
-				}
+		if (reveal) {
+			if (is_unseen) {
+				RevealUnseenBox(x - size / 2, y - size / 2, size, size, team);
+				affectedAny = true;
 			}
-
-			// Check the strength of the terrain to see if we can penetrate further
-			materialID = GetTerrMatter(intPos[X], intPos[Y]);
-			// Get the material object
-			foundMaterial = GetMaterialFromID(materialID);
-			// Add the encountered material's strength to the tally
-			totalStrength += foundMaterial->GetIntegrity();
-			// See if we have hit the limits of our ray's strength
-			if (totalStrength >= strengthLimit) {
-				// Save the position of the end of the ray where blocked
-				endPos.SetXY(intPos[X], intPos[Y]);
-				break;
-			}
-			// Reset skip counter
-			skipped = 0;
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
+		} else {
+			if (!is_unseen) {
+				RestoreUnseenBox(x - size / 2, y - size / 2, size, size, team);
+				affectedAny = true;
 			}
 		}
-	}
+
+		Material const* foundMaterial = GetMaterialFromID(GetTerrMatter(x, y));
+		totalStrength += foundMaterial->GetIntegrity();
+		if (totalStrength >= strengthLimit) {
+			endPos.SetXY(x, y);
+			return false;
+		}
+
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
+		}
+		return true;
+	    });
 
 	return affectedAny;
 }
@@ -1243,83 +1081,31 @@ bool SceneMan::CastUnseeRay(int team, const Vector& start, const Vector& ray, Ve
 }
 
 bool SceneMan::CastMaterialRay(const Vector& start, const Vector& ray, unsigned char material, Vector& result, int skip, bool wrap) {
-
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	bool foundPixel = false;
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0)
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y))
 		return false;
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	bool foundPixel = false;
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		if (wrap)
+			g_SceneMan.WrapPosition(x, y);
 
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
+		if (GetTerrMatter(x, y) == material) {
+			result.SetXY(x, y);
+			s_LastRayHitPos.SetXY(x, y);
+			foundPixel = true;
+			return false;
 		}
-		error += delta2[sub];
 
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			if (wrap)
-				g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			// See if we found the looked-for pixel of the correct material
-			if (GetTerrMatter(intPos[X], intPos[Y]) == material) {
-				// Save result and report success
-				foundPixel = true;
-				result.SetXY(intPos[X], intPos[Y]);
-				// Save last ray pos
-				s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-				break;
-			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-			}
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
 		}
-	}
+		return true;
+	    });
 
 	return foundPixel;
 }
@@ -1337,82 +1123,31 @@ float SceneMan::CastMaterialRay(const Vector& start, const Vector& ray, unsigned
 }
 
 bool SceneMan::CastNotMaterialRay(const Vector& start, const Vector& ray, unsigned char material, Vector& result, int skip, bool checkMOs) {
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	bool foundPixel = false;
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0)
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y))
 		return false;
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	bool foundPixel = false;
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
+		if (GetTerrMatter(x, y) != material ||
+		    (checkMOs && g_SceneMan.GetMOIDPixel(x, y, Activity::NoTeam) != g_NoMOID)) {
+			result.SetXY(x, y);
+			s_LastRayHitPos.SetXY(x, y);
+			foundPixel = true;
+			return false;
 		}
-		error += delta2[sub];
 
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			// See if we found the looked-for pixel of the correct material,
-			// Or an MO is blocking the way
-			if (GetTerrMatter(intPos[X], intPos[Y]) != material ||
-			    (checkMOs && g_SceneMan.GetMOIDPixel(intPos[X], intPos[Y], Activity::NoTeam) != g_NoMOID)) {
-				// Save result and report success
-				foundPixel = true;
-				result.SetXY(intPos[X], intPos[Y]);
-				// Save last ray pos
-				s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-				break;
-			}
-
-			skipped = 0;
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-			}
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
 		}
-	}
+		return true;
+	    });
 
 	return foundPixel;
 }
@@ -1433,78 +1168,26 @@ float SceneMan::CastStrengthSumRay(const Vector& start, const Vector& end, int s
 	Vector ray = g_SceneMan.ShortestDistance(start, end);
 	float strengthSum = 0;
 
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	unsigned char materialID;
-	Material foundMaterial;
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0)
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y))
 		return false;
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
-
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
+		unsigned char matID = GetTerrMatter(x, y);
+		if (matID != g_MaterialAir && matID != ignoreMaterial) {
+			strengthSum += GetMaterialFromID(matID)->GetIntegrity();
 		}
-		error += delta2[sub];
 
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			// Sum all strengths
-			materialID = GetTerrMatter(intPos[X], intPos[Y]);
-			if (materialID != g_MaterialAir && materialID != ignoreMaterial) {
-				strengthSum += GetMaterialFromID(materialID)->GetIntegrity();
-			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-			}
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
 		}
-	}
+		return true;
+	    });
 
 	return strengthSum;
 }
@@ -1517,678 +1200,284 @@ const Material* SceneMan::CastMaxStrengthRayMaterial(const Vector& start, const 
 	Vector ray = g_SceneMan.ShortestDistance(start, end);
 	const Material* strongestMaterial = GetMaterialFromID(MaterialColorKeys::g_MaterialAir);
 
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0) {
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y)) {
 		return strongestMaterial;
 	}
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
-
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
-		}
-		error += delta2[sub];
-
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			// Sum all strengths
-			unsigned char materialID = GetTerrMatter(intPos[X], intPos[Y]);
-			if (materialID != g_MaterialAir && materialID != ignoreMaterial) {
-				const Material* foundMaterial = GetMaterialFromID(materialID);
-				if (foundMaterial->GetIntegrity() > strongestMaterial->GetIntegrity()) {
-					strongestMaterial = foundMaterial;
-				}
-			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
+		unsigned char matID = GetTerrMatter(x, y);
+		if (matID != g_MaterialAir && matID != ignoreMaterial) {
+			const Material* foundMaterial = GetMaterialFromID(matID);
+			if (foundMaterial->GetIntegrity() > strongestMaterial->GetIntegrity()) {
+				strongestMaterial = foundMaterial;
 			}
 		}
-	}
+
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
+		}
+		return true;
+	    });
 
 	return strongestMaterial;
 }
 
 bool SceneMan::CastStrengthRay(const Vector& start, const Vector& ray, float strength, Vector& result, int skip, unsigned char ignoreMaterial, bool wrap) {
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	bool foundPixel = false;
-	unsigned char materialID;
-	Material const* foundMaterial;
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0)
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y))
 		return false;
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	bool foundPixel = false;
+	int lastX = std::floor(start.m_X);
+	int lastY = std::floor(start.m_Y);
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		lastX = x;
+		lastY = y;
 
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
+		if (wrap)
+			g_SceneMan.WrapPosition(x, y);
 
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
-		}
-		error += delta2[sub];
-
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			if (wrap)
-				g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			materialID = GetTerrMatter(intPos[X], intPos[Y]);
-			// Ignore the ignore material
-			if (materialID != ignoreMaterial) {
-				// Get the material object
-				foundMaterial = GetMaterialFromID(materialID);
-
-				// See if we found a pixel of equal or more strength than the threshold
-				if (foundMaterial->GetIntegrity() >= strength) {
-					// Save result and report success
-					foundPixel = true;
-					result.SetXY(intPos[X], intPos[Y]);
-					// Save last ray pos
-					s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-					break;
-				}
-			}
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
+		unsigned char matID = GetTerrMatter(x, y);
+		if (matID != ignoreMaterial) {
+			Material const* foundMaterial = GetMaterialFromID(matID);
+			if (foundMaterial->GetIntegrity() >= strength) {
+				result.SetXY(x, y);
+				s_LastRayHitPos.SetXY(x, y);
+				foundPixel = true;
+				return false;
 			}
 		}
-	}
 
-	// If no pixel of sufficient strength was found, set the result to the final tried position
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
+		}
+		return true;
+	    });
+
 	if (!foundPixel)
-		result.SetXY(intPos[X], intPos[Y]);
+		result.SetXY(lastX, lastY);
 
 	return foundPixel;
 }
 
 bool SceneMan::CastWeaknessRay(const Vector& start, const Vector& ray, float strength, Vector& result, int skip, bool wrap) {
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	bool foundPixel = false;
-	unsigned char materialID;
-	Material const* foundMaterial;
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0)
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y))
 		return false;
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	bool foundPixel = false;
+	int lastX = std::floor(start.m_X);
+	int lastY = std::floor(start.m_Y);
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		lastX = x;
+		lastY = y;
 
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
+		if (wrap)
+			g_SceneMan.WrapPosition(x, y);
 
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
+		Material const* foundMaterial = GetMaterialFromID(GetTerrMatter(x, y));
 
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
+		if (foundMaterial->GetIntegrity() <= strength) {
+			result.SetXY(x, y);
+			s_LastRayHitPos.SetXY(x, y);
+			foundPixel = true;
+			return false;
 		}
-		error += delta2[sub];
 
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			if (wrap)
-				g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			materialID = GetTerrMatter(intPos[X], intPos[Y]);
-			foundMaterial = GetMaterialFromID(materialID);
-
-			// See if we found a pixel of equal or less strength than the threshold
-			if (foundMaterial->GetIntegrity() <= strength) {
-				// Save result and report success
-				foundPixel = true;
-				result.SetXY(intPos[X], intPos[Y]);
-				// Save last ray pos
-				s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-				break;
-			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-			}
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
 		}
-	}
+		return true;
+	    });
 
-	// If no pixel of sufficient strength was found, set the result to the final tried position
 	if (!foundPixel)
-		result.SetXY(intPos[X], intPos[Y]);
+		result.SetXY(lastX, lastY);
 
 	return foundPixel;
 }
 
 MOID SceneMan::CastMORay(const Vector& start, const Vector& ray, const std::vector<MOID>& ignoreMOIDs, int ignoreTeam, unsigned char ignoreMaterial, bool ignoreAllTerrain, int skip) {
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	MOID hitMOID = g_NoMOID;
-	unsigned char hitTerrain = 0;
-
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-
-	if (delta[X] == 0 && delta[Y] == 0)
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y))
 		return g_NoMOID;
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
+		MOID hitMOID = GetMOIDPixel(x, y, ignoreTeam);
 
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
-		}
-		error += delta2[sub];
-
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			// Detect MOIDs
-			hitMOID = GetMOIDPixel(intPos[X], intPos[Y], ignoreTeam);
-
-			// Loop through ignored MOIDs to see if the one we found is ignored
-			bool ignoredMOIDHit = false;
-			for (auto ignoredMOID : ignoreMOIDs) {
-				if (hitMOID == ignoredMOID || g_MovableMan.GetRootMOID(hitMOID) == ignoredMOID) {
-					ignoredMOIDHit = true;
-					break;
-				}
-			}
-			
-			if (hitMOID != g_NoMOID && !ignoredMOIDHit) {
-				// Save last ray pos
-				s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-				return hitMOID;
-			}
-
-			// Detect terrain hits
-			if (!ignoreAllTerrain) {
-				hitTerrain = g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]);
-				if (hitTerrain != g_MaterialAir && hitTerrain != ignoreMaterial) {
-					// Save last ray pos
-					s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-					return g_NoMOID;
-				}
-			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
+		bool ignoredMOIDHit = false;
+		for (auto ignoredMOID : ignoreMOIDs) {
+			if (hitMOID == ignoredMOID || g_MovableMan.GetRootMOID(hitMOID) == ignoredMOID) {
+				ignoredMOIDHit = true;
+				break;
 			}
 		}
-	}
 
-	// Didn't hit anything but air
+		if (hitMOID != g_NoMOID && !ignoredMOIDHit) {
+			s_LastRayHitPos.SetXY(x, y);
+			return false;
+		}
+
+		if (!ignoreAllTerrain) {
+			unsigned char hitTerrain = g_SceneMan.GetTerrMatter(x, y);
+			if (hitTerrain != g_MaterialAir && hitTerrain != ignoreMaterial) {
+				s_LastRayHitPos.SetXY(x, y);
+				return false;
+			}
+		}
+
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
+		}
+		return true;
+	    });
+
 	return g_NoMOID;
 }
 
 bool SceneMan::CastFindMORay(const Vector& start, const Vector& ray, MOID targetMOID, Vector& resultPos, unsigned char ignoreMaterial, bool ignoreAllTerrain, int skip, bool findChildMOIDs) {
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	MOID hitMOID = g_NoMOID;
-	unsigned char hitTerrain = 0;
+	if (std::floor(start.m_X + ray.m_X) == std::floor(start.m_X) && std::floor(start.m_Y + ray.m_Y) == std::floor(start.m_Y))
+		return false;
 
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
+	TraverseBresenhamLine(
+	    std::floor(start.m_X), std::floor(start.m_Y),
+	    std::floor(start.m_X + ray.m_X), std::floor(start.m_Y + ray.m_Y),
+	    skip,
+	    [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] == 0 && delta[Y] == 0)
-		return g_NoMOID;
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
-
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
-
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
+		MOID hitMOID = GetMOIDPixel(x, y, Activity::NoTeam);
+		if (hitMOID == targetMOID || (findChildMOIDs && hitMOID == g_MovableMan.GetRootMOID(targetMOID))) {
+			resultPos.SetXY(x, y);
+			s_LastRayHitPos.SetXY(x, y);
+			return false;
 		}
-		error += delta2[sub];
 
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			// Detect MOIDs
-			hitMOID = GetMOIDPixel(intPos[X], intPos[Y], Activity::NoTeam);
-			if (hitMOID == targetMOID || (findChildMOIDs && hitMOID == g_MovableMan.GetRootMOID(targetMOID))) {
-				// Found target MOID, so save result and report success
-				resultPos.SetXY(intPos[X], intPos[Y]);
-				// Save last ray pos
-				s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-				return true;
-			}
-
-			// Detect terrain hits
-			if (!ignoreAllTerrain) {
-				hitTerrain = g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]);
-				if (hitTerrain != g_MaterialAir && hitTerrain != ignoreMaterial) {
-					// Save last ray pos
-					s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-					return false;
-				}
-			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
+		if (!ignoreAllTerrain) {
+			unsigned char hitTerrain = g_SceneMan.GetTerrMatter(x, y);
+			if (hitTerrain != g_MaterialAir && hitTerrain != ignoreMaterial) {
+				s_LastRayHitPos.SetXY(x, y);
+				return false;
 			}
 		}
-	}
 
-	// Didn't hit the target
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
+		}
+		return true;
+	    });
+
 	return false;
 }
 
-const std::vector<MovableObject*>*  SceneMan::CastAllMOsRay(const Vector& start, const Vector& ray, const std::vector<MOID>& ignoreMOIDs, int ignoreTeam, unsigned char ignoreMaterial, bool ignoreAllTerrain, int skip) const {
+const std::vector<MovableObject*>* SceneMan::CastAllMOsRay(const Vector& start, const Vector& ray, const std::vector<MOID>& ignoreMOIDs, int ignoreTeam, unsigned char ignoreMaterial, bool ignoreAllTerrain, int skip) const {
 	std::vector<MovableObject*>* vectorForLua = new std::vector<MovableObject*>();
-
 	const SpatialPartitionGrid& partitionGrid = GetMOIDGrid();
 
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
-	unsigned char hitTerrain = 0;
+	int endX = std::floor(start.m_X + ray.m_X);
+	int endY = std::floor(start.m_Y + ray.m_Y);
 
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
+	TraverseBresenhamLine(start.m_X, start.m_Y, endX, endY, skip, [&](int& x, int& y, int) -> bool {
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] == 0 && delta[Y] == 0)
-		return vectorForLua;
+		std::vector<MovableObject*> hitMOs;
+		hitMOs = partitionGrid.GetMOsAtPosition(x, y, ignoreTeam, false);
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
-
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else
-		increment[X] = 1;
-
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else
-		increment[Y] = 1;
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] << 1;
-	delta2[Y] = delta[Y] << 1;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
-		}
-		error += delta2[sub];
-
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-				
-			// Detect MOs
-			std::vector<MovableObject*> hitMOs;
-			hitMOs = partitionGrid.GetMOsAtPosition(intPos[X], intPos[Y], ignoreTeam, false);
-
-			// Loop through the gotten MOs and check if we're ignoring their IDs - if not, put them onto our return vector
-			for (MovableObject* mo : hitMOs) {
-				MOID moid = mo->GetID();
-				for (auto ignoredMOID : ignoreMOIDs) {
-					if (moid != ignoredMOID && g_MovableMan.GetRootMOID(moid) != ignoredMOID) {
-						// Save last ray pos
-						s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-						vectorForLua->push_back(mo);
-					}
+		for (MovableObject* mo : hitMOs) {
+			MOID moid = mo->GetID();
+			for (auto ignoredMOID : ignoreMOIDs) {
+				if (moid != ignoredMOID && g_MovableMan.GetRootMOID(moid) != ignoredMOID) {
+					s_LastRayHitPos.SetXY(x, y);
+					vectorForLua->push_back(mo);
 				}
 			}
+		}
 
-			// Detect terrain hits
-			if (!ignoreAllTerrain) {
-				hitTerrain = g_SceneMan.GetTerrMatter(intPos[X], intPos[Y]);
-				if (hitTerrain != g_MaterialAir && hitTerrain != ignoreMaterial) {
-					// Save last ray pos
-					s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
-					return vectorForLua;
-				}
-			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
+		if (!ignoreAllTerrain) {
+			unsigned char hitTerrain = g_SceneMan.GetTerrMatter(x, y);
+			if (hitTerrain != g_MaterialAir && hitTerrain != ignoreMaterial) {
+				s_LastRayHitPos.SetXY(x, y);
+				return false;
 			}
 		}
-	}
 
-	// Didn't hit anything but air
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
+		}
+		return true;
+	});
+
 	return vectorForLua;
 }
 
 float SceneMan::CastObstacleRay(const Vector& start, const Vector& ray, Vector& obstaclePos, Vector& freePos, const std::vector<MOID>& ignoreMOIDs, int ignoreTeam, unsigned char ignoreMaterial, int skip) {
-	int error, dom, sub, domSteps, skipped = skip;
-	int intPos[2], delta[2], delta2[2], increment[2];
 	bool hitObstacle = false;
+	int lastStep = 0;
+	int endX = std::floor(start.m_X + ray.m_X);
+	int endY = std::floor(start.m_Y + ray.m_Y);
+	Vector startFraction(start.m_X - std::floor(start.m_X), start.m_Y - std::floor(start.m_Y));
 
-	intPos[X] = std::floor(start.m_X);
-	intPos[Y] = std::floor(start.m_Y);
-	delta[X] = std::floor(start.m_X + ray.m_X) - intPos[X];
-	delta[Y] = std::floor(start.m_Y + ray.m_Y) - intPos[Y];
-	// The fraction of a pixel that we start from, to be added to the integer result positions for accuracy
-	Vector startFraction(start.m_X - intPos[X], start.m_Y - intPos[Y]);
+	TraverseBresenhamLine(start.m_X, start.m_Y, endX, endY, skip, [&](int& x, int& y, int domStep) -> bool {
+		lastStep = domStep;
+		g_SceneMan.WrapPosition(x, y);
 
-	if (delta[X] == 0 && delta[Y] == 0) {
-		return -1.0f;
-	}
+		unsigned char checkMat = GetTerrMatter(x, y);
+		MOID checkMOID = GetMOIDPixel(x, y, ignoreTeam);
 
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm preparation
-
-	if (delta[X] < 0) {
-		increment[X] = -1;
-		delta[X] = -delta[X];
-	} else {
-		increment[X] = 1;
-	}
-
-	if (delta[Y] < 0) {
-		increment[Y] = -1;
-		delta[Y] = -delta[Y];
-	} else {
-		increment[Y] = 1;
-	}
-
-	// Scale by 2, for better accuracy of the error at the first pixel
-	delta2[X] = delta[X] * 2;
-	delta2[Y] = delta[Y] * 2;
-
-	// If X is dominant, Y is submissive, and vice versa.
-	if (delta[X] > delta[Y]) {
-		dom = X;
-		sub = Y;
-	} else {
-		dom = Y;
-		sub = X;
-	}
-
-	error = delta2[sub] - delta[dom];
-
-	/////////////////////////////////////////////////////
-	// Bresenham's line drawing algorithm execution
-
-	for (domSteps = 0; domSteps < delta[dom]; ++domSteps) {
-		intPos[dom] += increment[dom];
-		if (error >= 0) {
-			intPos[sub] += increment[sub];
-			error -= delta2[dom];
-		}
-		error += delta2[sub];
-
-		// Only check pixel if we're not due to skip any, or if this is the last pixel
-		if (++skipped > skip || domSteps + 1 == delta[dom]) {
-			// Scene wrapping, if necessary
-			g_SceneMan.WrapPosition(intPos[X], intPos[Y]);
-
-			unsigned char checkMat = GetTerrMatter(intPos[X], intPos[Y]);
-			MOID checkMOID = GetMOIDPixel(intPos[X], intPos[Y], ignoreTeam);
-
-			// Loop through ignored MOIDs to see if the one we found is ignored
-			bool ignoredMOIDHit = false;
-			for (auto ignoredMOID : ignoreMOIDs) {
-				if (checkMOID == ignoredMOID || g_MovableMan.GetRootMOID(checkMOID) == ignoredMOID) {
-					ignoredMOIDHit = true;
-					break;
-				}
-			}
-
-			// See if we found the looked-for pixel of the correct material,
-			// Or an MO is blocking the way
-			if ((checkMat != g_MaterialAir && checkMat != ignoreMaterial) || (checkMOID != g_NoMOID && !ignoredMOIDHit)) {
-				hitObstacle = true;
-				obstaclePos.SetXY(intPos[X], intPos[Y]);
-				// Save last ray pos
-				s_LastRayHitPos.SetXY(intPos[X], intPos[Y]);
+		bool ignoredMOIDHit = false;
+		for (auto ignoredMOID : ignoreMOIDs) {
+			if (checkMOID == ignoredMOID || g_MovableMan.GetRootMOID(checkMOID) == ignoredMOID) {
+				ignoredMOIDHit = true;
 				break;
-			} else {
-				freePos.SetXY(intPos[X], intPos[Y]);
 			}
-
-			skipped = 0;
-
-			if (m_pDebugLayer && m_DrawRayCastVisualizations) {
-				m_pDebugLayer->SetPixel(intPos[X], intPos[Y], 13);
-			}
-		} else {
-			freePos.SetXY(intPos[X], intPos[Y]);
 		}
-	}
 
-	// Add the pixel fraction to the free position if there were any free pixels
-	if (domSteps != 0) {
+		if ((checkMat != g_MaterialAir && checkMat != ignoreMaterial) || (checkMOID != g_NoMOID && !ignoredMOIDHit)) {
+			hitObstacle = true;
+			obstaclePos.SetXY(x, y);
+			s_LastRayHitPos.SetXY(x, y);
+			return false;
+		}
+
+		freePos.SetXY(x, y);
+
+		if (m_pDebugLayer && m_DrawRayCastVisualizations) {
+			m_pDebugLayer->SetPixel(x, y, 13);
+		}
+		return true;
+	});
+
+	if (lastStep != 0) {
 		freePos += startFraction;
 	}
 
 	if (hitObstacle) {
-		// Add the pixel fraction to the obstacle position, to acoid losing precision
 		obstaclePos += startFraction;
-		if (domSteps == 0) {
-			// If there was an obstacle on the start position, return 0 as the distance to obstacle
+		if (lastStep == 0) {
 			return 0.0F;
 		} else {
-			// Calculate the length between the start and the found material pixel coords
 			return g_SceneMan.ShortestDistance(obstaclePos, start).GetMagnitude();
 		}
 	}
 
-	// Didn't hit anything but air
 	return -1.0F;
 }
 

--- a/Source/Managers/UInputMan.cpp
+++ b/Source/Managers/UInputMan.cpp
@@ -1031,7 +1031,6 @@ int UInputMan::Update() {
 
 	UpdateMouseInput();
 	UpdateJoystickDigitalAxis();
-	HandleSpecialInput();
 
 	return 0;
 }

--- a/Source/Managers/UInputMan.h
+++ b/Source/Managers/UInputMan.h
@@ -583,9 +583,11 @@ namespace RTE {
 #pragma endregion
 
 #pragma region Update Breakdown
+	public:
 		/// Capture and handle special key shortcuts and combinations. This is called from Update().
 		void HandleSpecialInput();
 
+	protected:
 		/// Handles the mouse input in network multiplayer. This is called from Update().
 		void UpdateNetworkMouseMovement();
 

--- a/Source/Menus/SaveLoadMenuGUI.cpp
+++ b/Source/Menus/SaveLoadMenuGUI.cpp
@@ -21,8 +21,8 @@
 
 #include <execution>
 
-#include "zip.h"
-#include "unzip.h"
+#include "minizip/zip.h"
+#include "minizip/unzip.h"
 
 using namespace RTE;
 

--- a/Source/Menus/SaveLoadMenuGUI.cpp
+++ b/Source/Menus/SaveLoadMenuGUI.cpp
@@ -21,8 +21,13 @@
 
 #include <execution>
 
-#include "minizip/zip.h"
-#include "minizip/unzip.h"
+#ifdef SYSTEM_MINIZIP
+#include <minizip/zip.h>
+#include <minizip/unzip.h>
+#else
+#include "zip.h"
+#include "unzip.h"
+#endif
 
 using namespace RTE;
 

--- a/Source/Renderer/Shader.cpp
+++ b/Source/Renderer/Shader.cpp
@@ -61,6 +61,7 @@ int Shader::Create(const Shader& ref) {
 	m_UVTransformUniform = ref.m_UVTransformUniform;
 	m_ProjectionUniform = ref.m_ProjectionUniform;
 	std::copy(ref.m_Locations.begin(), ref.m_Locations.end(), m_Locations.begin());
+	m_UniformCache = ref.m_UniformCache;
 	return 0;
 }
 
@@ -110,21 +111,29 @@ void Shader::End() const {
 	rlClearActiveTextures();
 }
 
-GLint Shader::GetUniformLocation(const std::string& name) const { return glGetUniformLocation(m_ProgramID, name.c_str()); }
+GLint Shader::GetUniformLocation(const std::string& name) const {
+	auto it = m_UniformCache.find(name);
+	if (it != m_UniformCache.end()) {
+		return it->second;
+	}
+	GLint location = glGetUniformLocation(m_ProgramID, name.c_str());
+	m_UniformCache[name] = location;
+	return location;
+}
 
-void Shader::SetBool(const std::string& name, bool value) const { GL_CHECK(glUniform1i(glGetUniformLocation(m_ProgramID, name.c_str()), static_cast<int>(value))); }
+void Shader::SetBool(const std::string& name, bool value) const { GL_CHECK(glUniform1i(GetUniformLocation(name), static_cast<int>(value))); }
 
-void Shader::SetInt(const std::string& name, int value) const { GL_CHECK(glUniform1i(glGetUniformLocation(m_ProgramID, name.c_str()), value)); }
+void Shader::SetInt(const std::string& name, int value) const { GL_CHECK(glUniform1i(GetUniformLocation(name), value)); }
 
-void Shader::SetFloat(const std::string& name, float value) const { GL_CHECK(glUniform1f(glGetUniformLocation(m_ProgramID, name.c_str()), value)); }
+void Shader::SetFloat(const std::string& name, float value) const { GL_CHECK(glUniform1f(GetUniformLocation(name), value)); }
 
-void Shader::SetMatrix4f(const std::string& name, const glm::mat4& value) const { GL_CHECK(glUniformMatrix4fv(glGetUniformLocation(m_ProgramID, name.c_str()), 1, GL_FALSE, glm::value_ptr(value))); }
+void Shader::SetMatrix4f(const std::string& name, const glm::mat4& value) const { GL_CHECK(glUniformMatrix4fv(GetUniformLocation(name), 1, GL_FALSE, glm::value_ptr(value))); }
 
-void Shader::SetVector2f(const std::string& name, const glm::vec2& value) const { GL_CHECK(glUniform2fv(glGetUniformLocation(m_ProgramID, name.c_str()), 1, glm::value_ptr(value))); }
+void Shader::SetVector2f(const std::string& name, const glm::vec2& value) const { GL_CHECK(glUniform2fv(GetUniformLocation(name), 1, glm::value_ptr(value))); }
 
-void Shader::SetVector3f(const std::string& name, const glm::vec3& value) const { GL_CHECK(glUniform3fv(glGetUniformLocation(m_ProgramID, name.c_str()), 1, glm::value_ptr(value))); }
+void Shader::SetVector3f(const std::string& name, const glm::vec3& value) const { GL_CHECK(glUniform3fv(GetUniformLocation(name), 1, glm::value_ptr(value))); }
 
-void Shader::SetVector4f(const std::string& name, const glm::vec4& value) const { GL_CHECK(glUniform4fv(glGetUniformLocation(m_ProgramID, name.c_str()), 1, glm::value_ptr(value))); }
+void Shader::SetVector4f(const std::string& name, const glm::vec4& value) const { GL_CHECK(glUniform4fv(GetUniformLocation(name), 1, glm::value_ptr(value))); }
 
 void Shader::SetBool(int32_t uniformLoc, bool value) const { GL_CHECK(glUniform1i(uniformLoc, value)); }
 
@@ -183,6 +192,8 @@ bool Shader::Link(GLuint vtxShader, GLuint fragShader) {
 	GL_CHECK(glDetachShader(m_ProgramID, fragShader));
 	GL_CHECK(glDeleteShader(vtxShader));
 	GL_CHECK(glDeleteShader(fragShader));
+
+	m_UniformCache.clear();
 
 	return true;
 }

--- a/Source/Renderer/Shader.h
+++ b/Source/Renderer/Shader.h
@@ -7,6 +7,7 @@
 #include "raylib/rlgl.h"
 
 #include <array>
+#include <unordered_map>
 
 namespace RTE {
 	class Shader: public Entity {
@@ -186,6 +187,7 @@ namespace RTE {
 		std::string m_FragmentPath{};
 		std::string m_VertexPath{};
 		GLuint m_ProgramID{0};
+		mutable std::unordered_map<std::string, GLint> m_UniformCache{};
 
 		/// Compiles a shader component from a data string.
 		/// @param shaderID

--- a/Source/System/BresenhamLine.cpp
+++ b/Source/System/BresenhamLine.cpp
@@ -1,0 +1,61 @@
+#include "BresenhamLine.h"
+
+namespace RTE {
+
+size_t TraverseBresenhamLine(int x0, int y0, int x1, int y1, int skip, std::function<bool(int& x, int& y, int domStep)> callback) {
+	int intPos[2] = {x0, y0};
+	int delta[2];
+	delta[0] = x1 - x0;
+	delta[1] = y1 - y0;
+
+	if (delta[0] == 0 && delta[1] == 0) {
+		return 0;
+	}
+
+	int increment[2] = {1, 1};
+	if (delta[0] < 0) {
+		increment[0] = -1;
+		delta[0] = -delta[0];
+	}
+	if (delta[1] < 0) {
+		increment[1] = -1;
+		delta[1] = -delta[1];
+	}
+
+	int delta2[2] = {delta[0] << 1, delta[1] << 1};
+
+	int dom = 0, sub = 1;
+	if (delta[0] > delta[1]) {
+		dom = 0;
+		sub = 1;
+	} else {
+		dom = 1;
+		sub = 0;
+	}
+
+	int error = delta2[sub] - delta[dom];
+	int skipped = 0;
+	size_t visitCount = 0;
+
+	for (int domSteps = 0; domSteps < delta[dom]; ++domSteps) {
+		intPos[dom] += increment[dom];
+		if (error >= 0) {
+			intPos[sub] += increment[sub];
+			error -= delta2[dom];
+		}
+		error += delta2[sub];
+
+		if (++skipped > skip || domSteps + 1 == delta[dom]) {
+			if (callback(intPos[0], intPos[1], domSteps)) {
+				++visitCount;
+			} else {
+				break;
+			}
+			skipped = 0;
+		}
+	}
+
+	return visitCount;
+}
+
+}

--- a/Source/System/BresenhamLine.h
+++ b/Source/System/BresenhamLine.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <functional>
+
+namespace RTE {
+
+/// Iterator-style Bresenham's line drawing algorithm.
+/// Traverses all integer grid positions from (x0,y0) to (x1,y1) and calls
+/// the callback for each position. The callback receives the current position
+/// and the current dominant-axis step count. The callback can optionally update
+/// x and y to modify the internal position for subsequent iterations (useful for
+/// scene wrapping).
+/// @param x0 Starting X coordinate (will be truncated toward zero).
+/// @param y0 Starting Y coordinate (will be truncated toward zero).
+/// @param x1 Ending X coordinate (will be truncated toward zero).
+/// @param y1 Ending Y coordinate (will be truncated toward zero).
+/// @param skip How many points to skip between callback invocations (0 = every point).
+/// @param callback Function called for each visited point. Parameters: (x, y, domStep).
+///                 x and y are references to the internal position - the callback can
+///                 modify them to affect subsequent iterations (e.g., for scene wrapping).
+///                 Return true to continue, false to stop.
+/// @return The number of points for which the callback was invoked.
+size_t TraverseBresenhamLine(int x0, int y0, int x1, int y1, int skip, std::function<bool(int& x, int& y, int domStep)> callback);
+
+}

--- a/Source/System/System.cpp
+++ b/Source/System/System.cpp
@@ -1,7 +1,11 @@
 #include "System.h"
 
 #include "RTETools.h"
-#include "minizip/unzip.h"
+#ifdef SYSTEM_MINIZIP
+#include <minizip/unzip.h>
+#else
+#include "unzip.h"
+#endif
 
 #include "RTEError.h"
 

--- a/Source/System/System.cpp
+++ b/Source/System/System.cpp
@@ -1,7 +1,7 @@
 #include "System.h"
 
 #include "RTETools.h"
-#include "unzip.h"
+#include "minizip/unzip.h"
 
 #include "RTEError.h"
 

--- a/Source/System/meson.build
+++ b/Source/System/meson.build
@@ -1,4 +1,5 @@
 sources += files(
+'BresenhamLine.cpp',
 'Base64/base64.cpp',
 'MicroPather/micropather.cpp',
 'Semver200/Semver200_comparator.cpp',

--- a/meson.build
+++ b/meson.build
@@ -185,6 +185,7 @@ if host_machine.system() in ['linux','darwin']
     dependency('tbb'),
     dependency('gl')
   ]
+  preprocessor_flags+=['-DSYSTEM_MINIZIP']
   if host_machine.system()=='darwin'
     deps += dependency('appleframeworks', modules: ['Foundation'])  
   endif


### PR DESCRIPTION
## Summary
- Extract inline Bresenham implementations into reusable `TraverseBresenhamLine` iterator in `Source/System/`
- Eliminates 14 duplicate implementations in SceneMan and cleans up FrameMan
- Remaining Bresenham instances in Atom/AtomGroup/MOSRotating are specialized collision detection routines (not candidates for extraction)

## Changes
- Added `Source/System/BresenhamLine.cpp` and `.h` with `TraverseBresenhamLine` utility
- Updated `Source/System/meson.build` to include new files
- Refactored `SceneMan.cpp`: CastObstacleRay, CastAllMOsRay, and related methods now use shared utility
- Cleaned up `FrameMan.cpp`: removed unused variable declarations in SharedDrawLine

## Testing
- Clean build with no new warnings introduced